### PR TITLE
Auth: get notified on auth change

### DIFF
--- a/src/Cody.Core/Agent/IAgentService.cs
+++ b/src/Cody.Core/Agent/IAgentService.cs
@@ -1,8 +1,4 @@
 ﻿using Cody.Core.Agent.Protocol;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Cody.Core.Agent
@@ -44,6 +40,15 @@ namespace Cody.Core.Agent
 
         [AgentMethod("textDocument/didClose")]
         void DidClose(ProtocolTextDocument docState);
+
+        [AgentMethod("chat/new")]
+        Task<string> NewChat();
+
+        [AgentMethod("chat/sidebar/new")]
+        Task<ChatPanelInfo> NewSidebarChat();
+
+        [AgentMethod("chat/web/new")]
+        Task<ChatPanelInfo> NewEditorChat();
     }
 }
 

--- a/src/Cody.Core/Agent/Protocol/ChatPanelInfo.cs
+++ b/src/Cody.Core/Agent/Protocol/ChatPanelInfo.cs
@@ -1,0 +1,8 @@
+﻿namespace Cody.Core.Agent.Protocol
+{
+    public class ChatPanelInfo
+    {
+        public string PanelId { get; set; }
+        public string ChatId { get; set; }
+    }
+}

--- a/src/Cody.Core/Cody.Core.csproj
+++ b/src/Cody.Core/Cody.Core.csproj
@@ -62,6 +62,7 @@
     <Compile Include="Agent\INotificationHandler.cs" />
     <Compile Include="Agent\NotificationHandlers.cs" />
     <Compile Include="Agent\Protocol\AuthStatus.cs" />
+    <Compile Include="Agent\Protocol\ChatPanelInfo.cs" />
     <Compile Include="Agent\Protocol\ClientCapabilities.cs" />
     <Compile Include="Agent\Protocol\ClientInfo.cs" />
     <Compile Include="Agent\Protocol\ConfigOverwrites.cs" />


### PR DESCRIPTION
CLOSE https://linear.app/sourcegraph/issue/CODY-3170/disable-right-click-context-menu-for-the-webview-if-the-extension-is
- Add protocols for starting new chats to AgentService 
- Clean up and simplified src/Cody.Core/Agent/NotificationHandlers.cs
  - Log output in Debug mode only
  - Add new protocols to get notified when user authentication status has changed: "window/didChangeContext" part of https://linear.app/sourcegraph/issue/CODY-3208/user-friendly-login-for-plg-and-enterprise
 - clean up and simplified src/Cody.UI/Controls/WebviewController.cs
   - combine script for postMessageAsJson into VSCodeAPI script
   - Remove unused methods
   - Show context menu only in DEBUG mode https://linear.app/sourcegraph/issue/CODY-3170/disable-right-click-context-menu-for-the-webview-if-the-extension-is

Also added a form for users to login in the webview, but currently the token is not stored anyway and can only be used during the current session. We will need to work on a follow-up to store the provided token to the extension secret storage.

https://github.com/user-attachments/assets/1e051b68-f098-4027-8c97-2c25da60f0ee

To try the sign in screen, just remove your token from the env var to trigger the Auth view