### PR TITLE
Agent: Use updated agent protocols

### DIFF
--- a/src/Cody.AgentTester/Program.cs
+++ b/src/Cody.AgentTester/Program.cs
@@ -66,6 +66,7 @@ namespace Cody.AgentTester
                     Webview = "native",
                     WebviewNativeConfig = new WebviewCapabilities
                     {
+                        View = WebviewView.Single,
                         CspSource = "'self' https://cody.vs",
                         WebviewBundleServingPrefix = "https://cody.vs",
                     },

--- a/src/Cody.Core/Agent/IAgentService.cs
+++ b/src/Cody.Core/Agent/IAgentService.cs
@@ -1,4 +1,6 @@
-﻿using Cody.Core.Agent.Protocol;
+using Cody.Core.Agent.Protocol;
+using System.Collections.Generic;
+using System;
 using System.Threading.Tasks;
 
 namespace Cody.Core.Agent
@@ -52,6 +54,6 @@ namespace Cody.Core.Agent
         Task<ChatPanelInfo> NewEditorChat();
 
         [AgentMethod("workspaceFolder/didChange")]
-        Task WorkspaceFolderDidChange(CodyFilePath path);
+        Task WorkspaceFolderDidChange(WorkspaceFolderDidChangeEvent uris);
     }
 }

--- a/src/Cody.Core/Agent/InitializeCallback.cs
+++ b/src/Cody.Core/Agent/InitializeCallback.cs
@@ -53,6 +53,7 @@ namespace Cody.Core.Agent
                     Webview = "native",
                     WebviewNativeConfig = new WebviewCapabilities
                     {
+                        View = WebviewView.Single,
                         CspSource = "'self' https://cody.vs",
                         WebviewBundleServingPrefix = "https://cody.vs",
                     },

--- a/src/Cody.Core/Agent/Protocol/WebviewCapabilities.cs
+++ b/src/Cody.Core/Agent/Protocol/WebviewCapabilities.cs
@@ -1,14 +1,15 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Cody.Core.Agent.Protocol
 {
     public class WebviewCapabilities
     {
         public string CspSource { get; set; }
         public string WebviewBundleServingPrefix { get; set; }
+        public WebviewView View { get; set; }
+    }
+
+    public enum WebviewView
+    {
+        Single,
+        Multiple
     }
 }

--- a/src/Cody.Core/Agent/Protocol/WorkspaceFolderDidChangeEvent.cs
+++ b/src/Cody.Core/Agent/Protocol/WorkspaceFolderDidChangeEvent.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Cody.Core.Agent.Protocol
+{
+    public class WorkspaceFolderDidChangeEvent
+    {
+        public List<string> Uris { get; set; }
+
+        public WorkspaceFolderDidChangeEvent()
+        {
+            Uris = new List<string>();
+        }
+    }
+
+}

--- a/src/Cody.Core/Cody.Core.csproj
+++ b/src/Cody.Core/Cody.Core.csproj
@@ -63,6 +63,7 @@
     <Compile Include="Agent\NotificationHandlers.cs" />
     <Compile Include="Agent\Protocol\AuthStatus.cs" />
     <Compile Include="Agent\Protocol\ChatPanelInfo.cs" />
+    <Compile Include="Agent\Protocol\WorkspaceFolderDidChangeEvent.cs" />
     <Compile Include="Agent\Protocol\TextDocumentShowParamsOptions.cs" />
     <Compile Include="Agent\Protocol\TextDocumentShowParams.cs" />
     <Compile Include="Agent\Protocol\CodyFilePath.cs" />

--- a/src/Cody.VisualStudio/CodyPackage.cs
+++ b/src/Cody.VisualStudio/CodyPackage.cs
@@ -261,7 +261,11 @@ namespace Cody.VisualStudio
             try
             {
                 var solutionUri = new Uri(SolutionService.GetSolutionDirectory()).AbsoluteUri;
-                AgentService.WorkspaceFolderDidChange(new CodyFilePath { Uri = solutionUri });
+                var workspaceFolderEvent = new WorkspaceFolderDidChangeEvent
+                {
+                    Uris = new List<string> { solutionUri }
+                };
+                AgentService.WorkspaceFolderDidChange(workspaceFolderEvent);
 
                 if (DocumentsSyncService == null)
                 {
@@ -281,8 +285,12 @@ namespace Cody.VisualStudio
             try
             {
                 DocumentsSyncService?.Deinitialize();
-                // TODO: Implement workspace folder on close.
-                // AgentService.WorkspaceFolderDidChange(new CodyFilePath { Uri = "" });
+                var workspaceFolderEvent = new WorkspaceFolderDidChangeEvent
+                {
+                    Uris = new List<string>()
+                };
+                AgentService.WorkspaceFolderDidChange(workspaceFolderEvent);
+
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Update to use the latest changes for the agent protocols from https://github.com/sourcegraph/cody/pull/5211

This let agent knows when we have a workspace added or removed.

Also updated to use `View = WebviewView.Single,` for webview to always run chats in sidebar view

```

22:05:32.767: [ProcessId:38884] [ThreadId:5] Debug [AgentJsonMessageFormatter.OnSerializationComplete] Sending to agent: {"jsonrpc":"2.0","id":3,"method":"workspaceFolder/didChange","params":[{"uris":["file:///C:/Users/BeatrixW/source/repos/TestingApp"]}]}
```