### PR TITLE
Turn off "Cody Agent" output pane switching (activating) after every error

### DIFF
--- a/src/Cody.VisualStudio/CodyPackage.cs
+++ b/src/Cody.VisualStudio/CodyPackage.cs
@@ -104,8 +104,9 @@ namespace Cody.VisualStudio
         private void InitializeServices()
         {
             var loggerFactory = new LoggerFactory();
+            AgentLogger = loggerFactory.Create(WindowPaneLogger.CodyAgent);
             Logger = loggerFactory.Create("Cody");
-            AgentLogger = loggerFactory.Create("Cody agent");
+
             var vsSolution = this.GetService<SVsSolution, IVsSolution>();
             SolutionService = new SolutionService(vsSolution);
             VersionService = loggerFactory.GetVersionService();

--- a/src/Cody.VisualStudio/Infrastructure/WindowPaneLogger.cs
+++ b/src/Cody.VisualStudio/Infrastructure/WindowPaneLogger.cs
@@ -11,14 +11,18 @@ namespace Cody.VisualStudio.Inf
 {
     public class WindowPaneLogger : IOutputWindowPane
     {
+        public static string CodyAgent = "Cody Agent";
+
         private readonly IVsOutputWindow _outputWindow;
         private readonly IVsOutputWindowPane _pane;
 
         private Guid _guid = Guid.NewGuid();
+        private string _name;
 
         public WindowPaneLogger(IVsOutputWindow outputWindow, string name)
         {
             _outputWindow = outputWindow;
+            _name = name;
 
             if (_outputWindow.GetPane(_guid, out _pane) != VSConstants.S_OK)
             {
@@ -60,7 +64,7 @@ namespace Cody.VisualStudio.Inf
             Log(message, "Error", callerName);
 
 #if DEBUG
-            if (_pane != null)
+            if (_pane != null && _name != CodyAgent)
                 _pane.Activate();
 #endif
         }


### PR DESCRIPTION
CLOSE https://linear.app/sourcegraph/issue/CODY-3334/stop-agent-cody-output-pane-showing-every-time-when-there-is-an-error

Turn off "Cody Agent" output pane switching (activating) for every error logged which makes debugging experience less annoying.
