### PR TITLE
Fix for doc synch; other improvements

### DIFF
--- a/src/Cody.Core/Agent/IAgentService.cs
+++ b/src/Cody.Core/Agent/IAgentService.cs
@@ -5,6 +5,9 @@ using System.Threading.Tasks;
 
 namespace Cody.Core.Agent
 {
+    //---------------------------------------------------------
+    // For notifications return type MUST be void!
+    //---------------------------------------------------------
     public interface IAgentService
     {
         [AgentMethod("initialize")]
@@ -27,7 +30,6 @@ namespace Cody.Core.Agent
 
         [AgentMethod("extensionConfiguration/change")]
         Task<AuthStatus> ConfigurationChange(ExtensionConfiguration configuration);
-
 
         [AgentMethod("textDocument/didOpen")]
         void DidOpen(ProtocolTextDocument docState);
@@ -54,6 +56,10 @@ namespace Cody.Core.Agent
         Task<ChatPanelInfo> NewEditorChat();
 
         [AgentMethod("workspaceFolder/didChange")]
-        Task WorkspaceFolderDidChange(WorkspaceFolderDidChangeEvent uris);
+        void WorkspaceFolderDidChange(WorkspaceFolderDidChangeEvent uris);
+
+        //---------------------------------------------------------
+        // For notifications return type MUST be void!
+        //---------------------------------------------------------
     }
 }

--- a/src/Cody.VisualStudio/Client/AgentClient.cs
+++ b/src/Cody.VisualStudio/Client/AgentClient.cs
@@ -42,6 +42,7 @@ namespace Cody.VisualStudio.Client
             var handler = new HeaderDelimitedMessageHandler(connector.SendingStream, connector.ReceivingStream, jsonMessageFormatter);
 
             jsonRpc = new JsonRpc(handler);
+            jsonRpc.Disconnected += OnDisconnected;
 
             foreach (var target in options.NotificationHandlers)
             {
@@ -52,6 +53,11 @@ namespace Cody.VisualStudio.Client
             jsonRpc.StartListening();
             IsConnected = true;
             log.Info("A connection with the agent has been established.");
+        }
+
+        private void OnDisconnected(object sender, JsonRpcDisconnectedEventArgs e)
+        {
+            log.Error($"Agent disconnected due to {e.Description} (reason: {e.Reason})", e.Exception);
         }
 
         public T CreateAgentService<T>() where T : class


### PR DESCRIPTION
- Fix for document sync: In some cases, wrong active document was selected after opening the solution.
- Added logging for situations when the connection to the agent is dropped.
- `workspaceFolder/didChange` is now sent as a notification