### PR TITLE
Chat: Fix GlobalState type

### DIFF
--- a/src/Cody.AgentTester/Program.cs
+++ b/src/Cody.AgentTester/Program.cs
@@ -71,6 +71,7 @@ namespace Cody.AgentTester
                         WebviewBundleServingPrefix = "https://cody.vs",
                     },
                     WebviewMessages = "string-encoded",
+                    GlobalState = "stateless",
                 },
                 ExtensionConfiguration = new ExtensionConfiguration
                 {

--- a/src/Cody.Core/Agent/InitializeCallback.cs
+++ b/src/Cody.Core/Agent/InitializeCallback.cs
@@ -1,4 +1,3 @@
-using System;
 using Cody.Core.Agent.Protocol;
 using Cody.Core.Ide;
 using Cody.Core.Inf;
@@ -58,6 +57,7 @@ namespace Cody.Core.Agent
                         WebviewBundleServingPrefix = "https://cody.vs",
                     },
                     WebviewMessages = "string-encoded",
+                    GlobalState = "server-managed",
                 },
                 ExtensionConfiguration = GetConfiguration()
             };

--- a/src/Cody.Core/Agent/Protocol/ClientCapabilities.cs
+++ b/src/Cody.Core/Agent/Protocol/ClientCapabilities.cs
@@ -1,9 +1,3 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Cody.Core.Agent.Protocol
 {
     public class ClientCapabilities
@@ -20,9 +14,10 @@ namespace Cody.Core.Agent.Protocol
         public ShowWindowMessageCapability? ShowWindowMessage { get; set; }
         public Capability? Ignore { get; set; }
         public Capability? CodeActions { get; set; }
-        public string WebviewMessages { get; set; }
-        public string Webview { get; set; }
+        public string WebviewMessages { get; set; } // 'object-encoded' | 'string-encoded'
+        public string Webview { get; set; } // 'agentic' | 'native'
         public WebviewCapabilities WebviewNativeConfig { get; set; }
+        public string GlobalState { get; set; } // 'stateless' | 'server-managed' | 'client-managed'
     }
 
     public enum Capability

--- a/src/Cody.Core/Agent/Protocol/ClientInfo.cs
+++ b/src/Cody.Core/Agent/Protocol/ClientInfo.cs
@@ -1,9 +1,3 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Cody.Core.Agent.Protocol
 {
     public class ClientInfo
@@ -14,6 +8,7 @@ namespace Cody.Core.Agent.Protocol
         public string WorkspaceRootUri { get; set; }
         public ExtensionConfiguration ExtensionConfiguration { get; set; }
         public ClientCapabilities Capabilities { get; set; }
+        public string GlobalStateDir { get; set; }
 
     }
 }

--- a/src/Cody.UI/Controls/WebviewController.cs
+++ b/src/Cody.UI/Controls/WebviewController.cs
@@ -140,7 +140,6 @@ namespace Cody.UI.Controls
                 let state = undefined;
 
                 window.chrome.webview.addEventListener('message', e => {
-                    console.log('Send to webview', e.data)
                     const event = new CustomEvent('message');
                     event.data = e.data;
                     window.dispatchEvent(event)
@@ -153,10 +152,12 @@ namespace Cody.UI.Controls
                     acquired = true;
                     return Object.freeze({
                         postMessage: function(message) {
-                            console.log(`Send from webview: ${JSON.stringify(message)}`);
                             window.chrome.webview.postMessage(JSON.stringify(message));
                         },
                         setState: function(newState) {
+                            if (state === newState) {
+                                return;
+                            }
                             state = newState;
                             console.log(`Set State: ${JSON.stringify(newState)}`);
                             return newState;
@@ -174,7 +175,7 @@ namespace Cody.UI.Controls
 
         private static string GetThemeScript(string colorTheme) => $@"
             document.documentElement.dataset.ide = 'VisualStudio';
-            
+
             {colorTheme}
         ";
     }


### PR DESCRIPTION
Update GlobalState type to use string instead of enum because the server is getting "serverManaged" instead of "server-managed", which causing the globalState to be set to undefined in agent because that's not the type we recognize. 