### PR TITLE
Implement authentication and secret storage capability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
-- The chat view style now updates to match the theme of the editor on theme change. [pull/85](https://github.com/sourcegraph/cody-vs/pull/85)
+- Chat view style now matches the editor theme on theme changes. [pull/85](https://github.com/sourcegraph/cody-vs/pull/85)
+- Added browser-based authentication support. [pull/84](https://github.com/sourcegraph/cody-vs/pull/84)
 
 ### Changed
 

--- a/src/Cody.AgentTester/Cody.AgentTester.csproj
+++ b/src/Cody.AgentTester/Cody.AgentTester.csproj
@@ -50,6 +50,7 @@
   <ItemGroup>
     <Compile Include="AssemblyLoader.cs" />
     <Compile Include="ConsoleLogger.cs" />
+    <Compile Include="FakeSecretStorageProvider.cs" />
     <Compile Include="FakeServiceProvider.cs" />
     <Compile Include="MemorySettingsProvider.cs" />
     <Compile Include="Program.cs" />

--- a/src/Cody.AgentTester/FakeSecretStorageProvider.cs
+++ b/src/Cody.AgentTester/FakeSecretStorageProvider.cs
@@ -1,0 +1,33 @@
+using Microsoft.VisualStudio.Shell.Connected.CredentialStorage;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Cody.AgentTester
+{
+    public class FakeSecretStorageProvider: IVsCredentialStorageService
+    {
+        public IVsCredential Add(IVsCredentialKey key, string value)
+        {
+            throw new NotImplementedException();
+        }
+        public IVsCredential Retrieve(IVsCredentialKey key)
+        {
+            throw new NotImplementedException();
+        }
+        public IEnumerable<IVsCredential> RetrieveAll(string key)
+        {
+            throw new NotImplementedException();
+        }
+        public bool Remove(IVsCredentialKey key)
+        {
+            throw new NotImplementedException();
+        }
+        public IVsCredentialKey CreateCredentialKey(string a, string b, string c, string d)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Cody.AgentTester/FakeSecretStorageProvider.cs
+++ b/src/Cody.AgentTester/FakeSecretStorageProvider.cs
@@ -1,21 +1,22 @@
 using Microsoft.VisualStudio.Shell.Connected.CredentialStorage;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Cody.AgentTester
 {
-    public class FakeSecretStorageProvider: IVsCredentialStorageService
+    public class FakeSecretStorageProvider : IVsCredentialStorageService
     {
+        private Dictionary<IVsCredentialKey, IVsCredential> _credentials = new Dictionary<IVsCredentialKey, IVsCredential>();
+
         public IVsCredential Add(IVsCredentialKey key, string value)
         {
-            throw new NotImplementedException();
+            var credential = new FakeCredential(value);
+            _credentials[key] = credential;
+            return credential;
         }
         public IVsCredential Retrieve(IVsCredentialKey key)
         {
-            throw new NotImplementedException();
+            return _credentials[key];
         }
         public IEnumerable<IVsCredential> RetrieveAll(string key)
         {
@@ -23,11 +24,58 @@ namespace Cody.AgentTester
         }
         public bool Remove(IVsCredentialKey key)
         {
-            throw new NotImplementedException();
+            return _credentials.Remove(key);
         }
-        public IVsCredentialKey CreateCredentialKey(string a, string b, string c, string d)
+        public IVsCredentialKey CreateCredentialKey(string featureName, string resource, string userName, string type)
         {
-            throw new NotImplementedException();
+            return new FakeCredentialKey(featureName, resource, userName, type);
+        }
+
+        private class FakeCredentialKey : IVsCredentialKey
+        {
+            public string FeatureName { get; set; }
+            public string UserName { get; set; }
+            public string Type { get; set; }
+            public string Resource { get; set; }
+
+            public FakeCredentialKey(string featureName, string resource, string userName, string type)
+            {
+                FeatureName = featureName;
+                UserName = userName;
+                Type = type;
+                Resource = resource;
+            }
+        }
+
+        private class FakeCredential : IVsCredential
+        {
+            public string FeatureName { get; set; }
+            public string UserName { get; set; }
+            public string Type { get; set; }
+            public string Resource { get; set; }
+
+            public string TokenValue { get; set; }
+
+            public bool RefreshTokenValue()
+            {
+                return true;
+            }
+            public void SetTokenValue(string tokenValue)
+            {
+                TokenValue = tokenValue;
+            }
+            public string GetProperty(string name)
+            {
+                return name;
+            }
+            public bool SetProperty(string name, string value)
+            {
+                return true;
+            }
+            public FakeCredential(string tokenValue)
+            {
+                TokenValue = tokenValue;
+            }
         }
     }
 }

--- a/src/Cody.AgentTester/Program.cs
+++ b/src/Cody.AgentTester/Program.cs
@@ -32,9 +32,10 @@ namespace Cody.AgentTester
             var logger = new Logger();
             var settingsService = new UserSettingsService(new MemorySettingsProvider(), logger);
             var editorService = new FileService(new FakeServiceProvider(), logger);
+            var secretStorageService = new SecretStorageService(new FakeSecretStorageProvider());
             var options = new AgentClientOptions
             {
-                CallbackHandlers = new List<INotificationHandler> { new NotificationHandlers(settingsService, logger, editorService) },
+                CallbackHandlers = new List<INotificationHandler> { new NotificationHandlers(settingsService, logger, editorService, secretStorageService) },
                 AgentDirectory = "../../../Cody.VisualStudio/Agent",
                 RestartAgentOnFailure = true,
                 Debug = true,

--- a/src/Cody.AgentTester/Program.cs
+++ b/src/Cody.AgentTester/Program.cs
@@ -30,9 +30,9 @@ namespace Cody.AgentTester
             var portNumber = int.TryParse(devPort, out int port) ? port : 3113;
 
             var logger = new Logger();
-            var settingsService = new UserSettingsService(new MemorySettingsProvider(), logger);
-            var editorService = new FileService(new FakeServiceProvider(), logger);
             var secretStorageService = new SecretStorageService(new FakeSecretStorageProvider());
+            var settingsService = new UserSettingsService(new MemorySettingsProvider(), secretStorageService, logger);
+            var editorService = new FileService(new FakeServiceProvider(), logger);
             var options = new AgentClientOptions
             {
                 CallbackHandlers = new List<object> { new NotificationHandlers(settingsService, logger, editorService, secretStorageService) },
@@ -64,6 +64,7 @@ namespace Cody.AgentTester
                 WorkspaceRootUri = Directory.GetCurrentDirectory().ToString(),
                 Capabilities = new ClientCapabilities
                 {
+                    Authentication = Capability.Enabled,
                     Edit = Capability.Enabled,
                     EditWorkspace = Capability.None,
                     CodeLenses = Capability.None,
@@ -79,6 +80,7 @@ namespace Cody.AgentTester
                     },
                     WebviewMessages = "string-encoded",
                     GlobalState = "stateless",
+                    Secrets = "stateless",
                 },
                 ExtensionConfiguration = new ExtensionConfiguration
                 {

--- a/src/Cody.Core/Agent/InitializeCallback.cs
+++ b/src/Cody.Core/Agent/InitializeCallback.cs
@@ -43,6 +43,7 @@ namespace Cody.Core.Agent
                 WorkspaceRootUri = solutionService.GetSolutionDirectory(),
                 Capabilities = new ClientCapabilities
                 {
+                    Authentication = Capability.Enabled,
                     Completions = "none",
                     Edit = Capability.None,
                     EditWorkspace = Capability.None,
@@ -59,6 +60,7 @@ namespace Cody.Core.Agent
                     },
                     WebviewMessages = "string-encoded",
                     GlobalState = "server-managed",
+                    Secrets = "client-managed",
                 },
                 ExtensionConfiguration = GetConfiguration()
             };

--- a/src/Cody.Core/Agent/Protocol/ClientCapabilities.cs
+++ b/src/Cody.Core/Agent/Protocol/ClientCapabilities.cs
@@ -18,6 +18,8 @@ namespace Cody.Core.Agent.Protocol
         public string Webview { get; set; } // 'agentic' | 'native'
         public WebviewCapabilities WebviewNativeConfig { get; set; }
         public string GlobalState { get; set; } // 'stateless' | 'server-managed' | 'client-managed'
+        public string Secrets { get; set; } // 'stateless' | 'server-managed' | 'client-managed'
+        public Capability? Authentication { get; set; }
     }
 
     public enum Capability

--- a/src/Cody.Core/Cody.Core.csproj
+++ b/src/Cody.Core/Cody.Core.csproj
@@ -82,6 +82,7 @@
     <Compile Include="Agent\WebviewMessageHandler.cs" />
     <Compile Include="DocumentSync\DocumentSyncCallback.cs" />
     <Compile Include="DocumentSync\IDocumentSyncActions.cs" />
+    <Compile Include="Infrastructure\ISecretStorageService.cs" />
     <Compile Include="Workspace\IFileService.cs" />
     <Compile Include="Ide\IVsVersionService.cs" />
     <Compile Include="Infrastructure\WebViewsManager.cs" />

--- a/src/Cody.Core/Infrastructure/ISecretStorageService.cs
+++ b/src/Cody.Core/Infrastructure/ISecretStorageService.cs
@@ -5,5 +5,6 @@ namespace Cody.Core.Infrastructure
         void Set(string key, string value);
         string Get(string key);
         void Delete(string key);
+        string AccessToken { get; set; }
     }
 }

--- a/src/Cody.Core/Infrastructure/ISecretStorageService.cs
+++ b/src/Cody.Core/Infrastructure/ISecretStorageService.cs
@@ -1,0 +1,9 @@
+namespace Cody.Core.Infrastructure
+{
+    public interface ISecretStorageService
+    {
+        void Set(string key, string value);
+        string Get(string key);
+        void Delete(string key);
+    }
+}

--- a/src/Cody.Core/Infrastructure/ISolutionService.cs
+++ b/src/Cody.Core/Infrastructure/ISolutionService.cs
@@ -1,9 +1,3 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Cody.Core.Infrastructure
 {
     public interface ISolutionService

--- a/src/Cody.Core/Settings/IUserSettingsService.cs
+++ b/src/Cody.Core/Settings/IUserSettingsService.cs
@@ -8,6 +8,7 @@ namespace Cody.Core.Settings
 
         string AccessToken { get; set; }
         string ServerEndpoint { get; set; }
+        string CodySettings { get; set; }
         event EventHandler AuthorizationDetailsChanged;
     }
 }

--- a/src/Cody.UI/Controls/Options/GeneralOptionsControl.xaml
+++ b/src/Cody.UI/Controls/Options/GeneralOptionsControl.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="Cody.UI.Controls.Options.GeneralOptionsControl"
+<UserControl x:Class="Cody.UI.Controls.Options.GeneralOptionsControl"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
@@ -25,45 +25,45 @@
                 </Grid.ColumnDefinitions>
 
 
-                <!--Access Token-->
+                <!--Cody Configurations-->
                 <Label 
-                    Grid.Row="0"
+                    Grid.Row="1"
                     Grid.Column="0"
-                    Content="Access Token"
+                    Content="Cody Settings"
                     />
 
                 <TextBox
-                    Grid.Row="0"
+                    Grid.Row="1"
                     Grid.Column="1"
                     Width="400"
-                    Height="20"
-                    Text="{Binding AccessToken, Mode=TwoWay}"
-                    ToolTip="Paste your access token. To create an access token, go to 'Settings' and then 'Access tokens' on the Sourcegraph instance."
-                    Name="AccessTokenTextBox"
+                    Height="50"
+                    Text="{Binding Configurations, Mode=TwoWay}"
+                    ToolTip="Your Cody configuration JSON file."
+                    Name="ConfigurationsTextBox"
                     />
 
-                <!--Get a token-->
+                <!--Get Help-->
                 <Button 
                     Margin="0 5 0 0"
                     Grid.Row="2"
                     Grid.Column="1"
                     Height="25"
                     Width="100"
-                    Content="Get a token"
+                    Content="Get Help"
                     HorizontalAlignment="Left"
                     Command="{Binding ActivateBetaCommand}"
                 />
 
                 <!--Sourcegraph URL-->
                 <Label
-                    Grid.Row="1"
+                    Grid.Row="0"
                     Grid.Column="0"
                     Content="Sourcegraph URL"
                 />
 
                 <TextBox
                     Name="SourcegraphUrlTextBox"
-                    Grid.Row="1"
+                    Grid.Row="0"
                     Grid.Column="1"
                     Width="400"
                     Height="20"

--- a/src/Cody.UI/Controls/Options/GeneralOptionsControl.xaml.cs
+++ b/src/Cody.UI/Controls/Options/GeneralOptionsControl.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System.Windows.Controls;
+using System.Windows.Controls;
 
 namespace Cody.UI.Controls.Options
 {
@@ -16,8 +16,8 @@ namespace Cody.UI.Controls.Options
         {
             // TextBox binding doesn't work when Visual Studio closes Options window
             // This is a workaround to get bindings updated. The second solution is to use NotifyPropertyChange for every TextBox in the Xaml, but current solution is a little more "clean" - everything is clearly visible in a one place.
-            AccessTokenTextBox.GetBindingExpression(TextBox.TextProperty)?.UpdateSource();
             SourcegraphUrlTextBox.GetBindingExpression(TextBox.TextProperty)?.UpdateSource();
+            ConfigurationsTextBox.GetBindingExpression(TextBox.TextProperty)?.UpdateSource();
         }
     }
 }

--- a/src/Cody.UI/ViewModels/GeneralOptionsViewModel.cs
+++ b/src/Cody.UI/ViewModels/GeneralOptionsViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using Cody.Core.Logging;
 using Cody.UI.MVVM;
@@ -20,15 +20,15 @@ namespace Cody.UI.ViewModels
         private DelegateCommand _getTokenCommand;
         public DelegateCommand ActivateBetaCommand
         {
-            get { return _getTokenCommand = _getTokenCommand ?? new DelegateCommand(GetTokenCommandHandler); }
+            get { return _getTokenCommand = _getTokenCommand ?? new DelegateCommand(GetHelpCommandHandler); }
         }
 
-        private void GetTokenCommandHandler()
+        private void GetHelpCommandHandler()
         {
             var uri = string.Empty;
             try
             {
-                uri = new Uri("https://sourcegraph.com/user/settings/tokens").AbsoluteUri;
+                uri = new Uri("https://community.sourcegraph.com/").AbsoluteUri;
                 Process.Start(new ProcessStartInfo(uri));
             }
             catch(Exception ex)
@@ -37,16 +37,16 @@ namespace Cody.UI.ViewModels
             }
         }
 
-        private string _accessToken;
+        private string _codyConfig;
 
-        public string AccessToken
+        public string CodyConfigurations
         {
-            get => _accessToken;
+            get => _codyConfig;
             set
             {
-                if (SetProperty(ref _accessToken, value))
+                if (SetProperty(ref _codyConfig, value))
                 {
-                    _logger.Debug($"Access Token set:{AccessToken}");
+                    _logger.Debug($"Cody Configurations set:{CodyConfigurations}");
                 }
 
             }

--- a/src/Cody.VisualStudio.Tests/ChatNotLoggedStateTests.cs
+++ b/src/Cody.VisualStudio.Tests/ChatNotLoggedStateTests.cs
@@ -16,9 +16,9 @@ namespace Cody.VisualStudio.Tests
             await GetPackageAsync();
             CodyPackage.ShowOptionPage(typeof(GeneralOptionsPage));
             await Task.Delay(TimeSpan.FromSeconds(1)); // HACK: properly wait for Options page
-
-            var accessToken = CodyPackage.GeneralOptionsViewModel.AccessToken;
-            CodyPackage.GeneralOptionsViewModel.AccessToken = $"{accessToken}INVALID"; // make it invalid
+            // TODO: Replace SourcegraphUrl with Token value
+            var accessToken = CodyPackage.GeneralOptionsViewModel.SourcegraphUrl;
+            CodyPackage.GeneralOptionsViewModel.SourcegraphUrl = $"{accessToken}INVALID"; // make it invalid
 
             await WaitForPlaywrightAsync();
             
@@ -28,7 +28,7 @@ namespace Cody.VisualStudio.Tests
             var getStarted = Page.GetByText(text);
             var textContents = await getStarted.AllTextContentsAsync();
 
-            CodyPackage.GeneralOptionsViewModel.AccessToken = $"{accessToken}"; // make it valid
+            CodyPackage.GeneralOptionsViewModel.SourcegraphUrl = $"{accessToken}"; // make it valid
 
             // then
             Assert.Equal(text, textContents.First());

--- a/src/Cody.VisualStudio/Cody.VisualStudio.csproj
+++ b/src/Cody.VisualStudio/Cody.VisualStudio.csproj
@@ -65,6 +65,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="CodyPackage.cs" />
     <Compile Include="Properties\AssemblyVersion.cs" />
+    <Compile Include="Services\SecretStorageService.cs" />
     <Compile Include="Services\DocumentsSyncService.cs" />
     <Compile Include="Services\FileService.cs" />
     <Compile Include="Services\OptionsPage.cs">

--- a/src/Cody.VisualStudio/CodyPackage.cs
+++ b/src/Cody.VisualStudio/CodyPackage.cs
@@ -17,6 +17,7 @@ using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Connected.CredentialStorage;
 using Microsoft.VisualStudio.Shell.Events;
 using Microsoft.VisualStudio.Shell.Interop;
 using System;
@@ -76,6 +77,7 @@ namespace Cody.VisualStudio
         public ISolutionService SolutionService;
         public IWebViewsManager WebViewsManager;
         public IAgentProxy AgentClient;
+        public ISecretStorageService SecretStorageService;
 
         public MainView MainView;
         public InitializeCallback InitializeService;
@@ -120,12 +122,14 @@ namespace Cody.VisualStudio
             VsVersionService = new VsVersionService(Logger);
             UserSettingsService = new UserSettingsService(new UserSettingsProvider(this), Logger);
             UserSettingsService.AuthorizationDetailsChanged += AuthorizationDetailsChanged;
+            var vsSecretStorage = this.GetService<SVsCredentialStorageService, IVsCredentialStorageService>();
+            SecretStorageService = new SecretStorageService(vsSecretStorage);
 
             StatusbarService = new StatusbarService();
             InitializeService = new InitializeCallback(UserSettingsService, VersionService, VsVersionService, StatusbarService, SolutionService, Logger);
             ThemeService = new ThemeService(this);
             FileService = new FileService(this, Logger);
-            NotificationHandlers = new NotificationHandlers(UserSettingsService, AgentNotificationsLogger, FileService);
+            NotificationHandlers = new NotificationHandlers(UserSettingsService, AgentNotificationsLogger, FileService, SecretStorageService);
             NotificationHandlers.OnOptionsPageShowRequest += HandleOnOptionsPageShowRequest;
 
             WebView2Dev.InitializeController(ThemeService.GetThemingScript());

--- a/src/Cody.VisualStudio/CodyPackage.cs
+++ b/src/Cody.VisualStudio/CodyPackage.cs
@@ -127,16 +127,16 @@ namespace Cody.VisualStudio
             SolutionService = new SolutionService(vsSolution);
             VersionService = loggerFactory.GetVersionService();
             VsVersionService = new VsVersionService(Logger);
-            UserSettingsService = new UserSettingsService(new UserSettingsProvider(this), Logger);
-            UserSettingsService.AuthorizationDetailsChanged += AuthorizationDetailsChanged;
+
             var vsSecretStorage = this.GetService<SVsCredentialStorageService, IVsCredentialStorageService>();
             SecretStorageService = new SecretStorageService(vsSecretStorage);
+            UserSettingsService = new UserSettingsService(new UserSettingsProvider(this), SecretStorageService, Logger);
+            UserSettingsService.AuthorizationDetailsChanged += AuthorizationDetailsChanged;
 
             StatusbarService = new StatusbarService();
             InitializeService = new InitializeCallback(UserSettingsService, VersionService, VsVersionService, StatusbarService, SolutionService, Logger);
             ThemeService = new ThemeService(this);
             FileService = new FileService(this, Logger);
-            NotificationHandlers = new NotificationHandlers(UserSettingsService, AgentNotificationsLogger, FileService, SecretStorageService);
             var statusCenterService = this.GetService<SVsTaskStatusCenterService, IVsTaskStatusCenterService>();
             ProgressService = new ProgressService(statusCenterService);
             NotificationHandlers = new NotificationHandlers(UserSettingsService, AgentNotificationsLogger, FileService, SecretStorageService);

--- a/src/Cody.VisualStudio/Options/GeneralOptionsPage.cs
+++ b/src/Cody.VisualStudio/Options/GeneralOptionsPage.cs
@@ -58,10 +58,10 @@ namespace Cody.VisualStudio.Options
             _logger.Debug($"Settings page activated.");
 
 
-            var accessToken = _settingsService.AccessToken;
+            var codyConfig = _settingsService.CodySettings;
             var sourcegraphUrl = _settingsService.ServerEndpoint;
 
-            _generalOptionsViewModel.AccessToken = accessToken;
+            _generalOptionsViewModel.CodyConfigurations = codyConfig;
             _generalOptionsViewModel.SourcegraphUrl = sourcegraphUrl;
 
             _logger.Debug($"Is canceled:{e.Cancel}");
@@ -72,10 +72,10 @@ namespace Cody.VisualStudio.Options
         {
             _logger.Debug($"{args.ApplyBehavior}");
 
-            var accessToken = _generalOptionsViewModel.AccessToken;
+            var codyConfig = _generalOptionsViewModel.CodyConfigurations;
             var sourcegraphUrl = _generalOptionsViewModel.SourcegraphUrl;
 
-            _settingsService.AccessToken = accessToken;
+            _settingsService.CodySettings = codyConfig;
             _settingsService.ServerEndpoint = sourcegraphUrl;
         }
 
@@ -95,7 +95,7 @@ namespace Cody.VisualStudio.Options
 
         public override void ResetSettings()
         {
-            _settingsService.AccessToken = string.Empty;
+            _settingsService.CodySettings = string.Empty;
             _settingsService.ServerEndpoint = string.Empty;
 
             base.ResetSettings();

--- a/src/Cody.VisualStudio/Services/OptionsPage.cs
+++ b/src/Cody.VisualStudio/Services/OptionsPage.cs
@@ -6,13 +6,13 @@ namespace Cody.VisualStudio
     public class OptionsPage : DialogPage
     {
         [Category("Authentication")]
-        [DisplayName("Access Token")]
-        [Description("Paste your access token. To create an access token, go to 'Settings' and then 'Access tokens' on the Sourcegraph instance.")]
-        public string TokenKey { get; set; }
-
-        [Category("Authentication")]
         [DisplayName("Sourcegraph URL")]
-        [Description("Enter the URL of the Sourcegraph instance. For example, https://sourcegraph.example.com.")]
+        [Description("The URL of the Sourcegraph instance you are connecting to.")]
         public string Endpoint { get; set; }
+
+        [Category("Configurations")]
+        [DisplayName("Extension Settings")]
+        [Description("[Current Not Supported] Your Cody extension settings in JSON format.")]
+        public string Settings { get; set; }
     }
 }

--- a/src/Cody.VisualStudio/Services/SecretStorageService.cs
+++ b/src/Cody.VisualStudio/Services/SecretStorageService.cs
@@ -1,0 +1,38 @@
+using Cody.Core.Infrastructure;
+using Microsoft.VisualStudio.Shell.Connected.CredentialStorage;
+
+namespace Cody.VisualStudio.Services
+{
+    public class SecretStorageService: ISecretStorageService
+    {
+        private readonly IVsCredentialStorageService secretStorageService;
+        private readonly string FeatureName = "Cody.VisualStudio";
+        private readonly string UserName = "CodyAgent";
+        private readonly string Type = "token";
+
+        public SecretStorageService(IVsCredentialStorageService secretStorageService)
+        {
+            this.secretStorageService = secretStorageService;
+        }
+
+        public string Get(string key)
+        {
+            var credentialKey = this.secretStorageService.CreateCredentialKey(FeatureName, key, UserName, Type);
+            var credential = this.secretStorageService.Retrieve(credentialKey);
+            return credential?.TokenValue;
+
+        }
+
+        public void Set(string key, string value)
+        {
+            var credentialKey = this.secretStorageService.CreateCredentialKey(FeatureName, key, UserName, Type);
+            this.secretStorageService.Add(credentialKey, value);
+        }
+
+        public void Delete(string key)
+        {
+            var credentialKey = this.secretStorageService.CreateCredentialKey(FeatureName, key, UserName, Type);
+            this.secretStorageService.Remove(credentialKey);
+        }
+    }
+}

--- a/src/Cody.VisualStudio/Services/SecretStorageService.cs
+++ b/src/Cody.VisualStudio/Services/SecretStorageService.cs
@@ -3,9 +3,10 @@ using Microsoft.VisualStudio.Shell.Connected.CredentialStorage;
 
 namespace Cody.VisualStudio.Services
 {
-    public class SecretStorageService: ISecretStorageService
+    public class SecretStorageService : ISecretStorageService
     {
         private readonly IVsCredentialStorageService secretStorageService;
+        private readonly string AccessTokenKey = "cody.access-token";
         private readonly string FeatureName = "Cody.VisualStudio";
         private readonly string UserName = "CodyAgent";
         private readonly string Type = "token";
@@ -33,6 +34,18 @@ namespace Cody.VisualStudio.Services
         {
             var credentialKey = this.secretStorageService.CreateCredentialKey(FeatureName, key, UserName, Type);
             this.secretStorageService.Remove(credentialKey);
+        }
+
+        public string AccessToken
+        {
+            get
+            {
+                return this.Get(AccessTokenKey);
+            }
+            set
+            {
+                this.Set(AccessTokenKey, value);
+            }
         }
     }
 }

--- a/src/build.cake
+++ b/src/build.cake
@@ -24,7 +24,7 @@ var codyRepo = "https://github.com/sourcegraph/cody.git";
 var nodeBinaryUrl = "https://github.com/sourcegraph/node-binaries/raw/main/v20.12.2/node-win-x64.exe";
 var nodeArmBinaryUrl = "https://github.com/sourcegraph/node-binaries/raw/main/v20.12.2/node-win-arm64.exe";
 
-var codyCommit = "5bb199df24ceb3668a02e80c08fead2f65720d15";
+var codyCommit = "9a7e712ffce1b90bf2627dd528a68a803b7959ee";
 
 var marketplaceToken = EnvironmentVariable("CODY_VS_MARKETPLACE_RELEASE_TOKEN");
 


### PR DESCRIPTION
CLOSE https://github.com/sourcegraph/cody-vs/issues/72 https://linear.app/sourcegraph/issue/CODY-3619/implement-ivscredentialstorageservice-interface-for-storing-secrets https://linear.app/sourcegraph/issue/CODY-3618/agent-api-for-secret-storage-capability https://linear.app/sourcegraph/issue/CODY-3617/implement-agent-requests-for-secret-storage-capability

Try logout and then log back into Cody to confirm you can now use token redirect and secret storage via Agent:

![image](https://github.com/user-attachments/assets/cf7c1838-11a5-44d0-b655-eeb639259abe)

This PR enables client capability for authentication (added in https://github.com/sourcegraph/cody/pull/5325) and secrets (added in https://github.com/sourcegraph/cody/pull/5348) that allows users to use the native webview for authentication in Cody for Visual Studio. 

The protocols for secret storage operations have also been implemented and the secrets will be stored in [IVsCredentialStorageService](https://learn.microsoft.com/en-us/dotnet/api/microsoft.visualstudio.shell.connected.credentialstorage?view=visualstudiosdk-2017). 

Demo:

https://github.com/user-attachments/assets/d21c8c2f-2667-426a-9c4d-991b7645d2e5