### PR TITLE
Update webview theme on editor theme change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- The chat view style now updates to match the theme of the editor on theme change. [pull/85](https://github.com/sourcegraph/cody-vs/pull/85)
+
 ### Changed
 
 ### Deprecated

--- a/src/Cody.Core/Infrastructure/IColorThemeService.cs
+++ b/src/Cody.Core/Infrastructure/IColorThemeService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -8,6 +8,8 @@ namespace Cody.Core.Infrastructure
 {
     public interface IThemeService
     {
+        event EventHandler<IColorThemeChangedEvent> ThemeChanged;
+
         bool IsDarkTheme();
 
         IReadOnlyDictionary<string, string> GetColors();
@@ -31,4 +33,9 @@ namespace Cody.Core.Infrastructure
 
         public float Size { get; protected set; }
     }
+}
+
+public class IColorThemeChangedEvent : EventArgs
+{
+    public string ThemingScript { get; set; }
 }

--- a/src/Cody.UI/Controls/WebView2Dev.xaml.cs
+++ b/src/Cody.UI/Controls/WebView2Dev.xaml.cs
@@ -31,9 +31,11 @@ namespace Cody.UI.Controls
             await InitializeWebView();
         }
 
-        public static WebviewController InitializeController(string themeScript)
+        public static WebviewController InitializeController(string themeScript, ILog logger)
         {
+            _controller.SetLogger(logger);
             _controller.SetThemeScript(themeScript);
+
             return _controller;
         }
 

--- a/src/Cody.UI/Controls/WebviewController.cs
+++ b/src/Cody.UI/Controls/WebviewController.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
+using Cody.Core.Logging;
 
 namespace Cody.UI.Controls
 {
@@ -15,6 +16,8 @@ namespace Cody.UI.Controls
         private string _colorThemeScript;
 
         private ICommand _sendMessageCommand;
+
+        private ILog _logger;
 
         public WebviewController()
         {
@@ -139,11 +142,22 @@ namespace Cody.UI.Controls
 
         public async void OnThemeChanged(object sender, IColorThemeChangedEvent e)
         {
-            string updatedScript = e.ThemingScript;
-            if (updatedScript != _colorThemeScript)
+            try
             {
-                SetThemeScript(updatedScript);
-                await ApplyThemingScript();
+                string updatedScript = e.ThemingScript;
+                if (updatedScript != _colorThemeScript)
+                {
+                    _logger.Debug("Applying VS theme change to WebView ...");
+
+                    SetThemeScript(updatedScript);
+                    await ApplyThemingScript();
+
+                    _logger.Debug("Theme change applied.");
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.Error("Applying theme change to WebView failed.", ex);
             }
         }
 
@@ -201,5 +215,10 @@ namespace Cody.UI.Controls
                 {colorTheme}
             }})();
         ";
+
+        public void SetLogger(ILog logger)
+        {
+            _logger = logger;
+        }
     }
 }

--- a/src/Cody.UI/Controls/WebviewController.cs
+++ b/src/Cody.UI/Controls/WebviewController.cs
@@ -135,10 +135,6 @@ namespace Cody.UI.Controls
         public void SetThemeScript(string colorThemeScript)
         {
             _colorThemeScript = colorThemeScript;
-            // We might want to apply the theme immediately if the webview is already loaded.
-            // if (_webview.CoreWebView2.IsDocumentOpen) {
-            //     _ = ApplyThemingScript();
-            // }
         }
 
         public async void OnThemeChanged(object sender, IColorThemeChangedEvent e)

--- a/src/Cody.UI/Controls/WebviewController.cs
+++ b/src/Cody.UI/Controls/WebviewController.cs
@@ -137,8 +137,18 @@ namespace Cody.UI.Controls
             _colorThemeScript = colorThemeScript;
             // We might want to apply the theme immediately if the webview is already loaded.
             // if (_webview.CoreWebView2.IsDocumentOpen) {
-            //     _ = ApplyThemingScript(); 
+            //     _ = ApplyThemingScript();
             // }
+        }
+
+        public async void OnThemeChanged(object sender, IColorThemeChangedEvent e)
+        {
+            string updatedScript = e.ThemingScript;
+            if (updatedScript != _colorThemeScript)
+            {
+                SetThemeScript(updatedScript);
+                await ApplyThemingScript();
+            }
         }
 
         public void SetHtml(string html)
@@ -189,9 +199,11 @@ namespace Cody.UI.Controls
         ";
 
         private static string GetThemeScript(string colorTheme) => $@"
-            document.documentElement.dataset.ide = 'VisualStudio';
-
-            {colorTheme}
+            (function() {{
+                document.documentElement.dataset.ide = 'VisualStudio';
+                document.documentElement.style = '';
+                {colorTheme}
+            }})();
         ";
     }
 }

--- a/src/Cody.VisualStudio/CodyPackage.cs
+++ b/src/Cody.VisualStudio/CodyPackage.cs
@@ -130,7 +130,7 @@ namespace Cody.VisualStudio
 
             StatusbarService = new StatusbarService();
             InitializeService = new InitializeCallback(UserSettingsService, VersionService, VsVersionService, StatusbarService, SolutionService, Logger);
-            ThemeService = new ThemeService(this);
+            ThemeService = new ThemeService(this, Logger);
             FileService = new FileService(this, Logger);
             var statusCenterService = this.GetService<SVsTaskStatusCenterService, IVsTaskStatusCenterService>();
             ProgressService = new ProgressService(statusCenterService);
@@ -138,7 +138,7 @@ namespace Cody.VisualStudio
             NotificationHandlers.OnOptionsPageShowRequest += HandleOnOptionsPageShowRequest;
             ProgressNotificationHandlers = new ProgressNotificationHandlers(ProgressService);
 
-            var sidebarController = WebView2Dev.InitializeController(ThemeService.GetThemingScript());
+            var sidebarController = WebView2Dev.InitializeController(ThemeService.GetThemingScript(), Logger);
             ThemeService.ThemeChanged += sidebarController.OnThemeChanged;
             NotificationHandlers.PostWebMessageAsJson = WebView2Dev.PostWebMessageAsJson;
 

--- a/src/Cody.VisualStudio/CodyPackage.cs
+++ b/src/Cody.VisualStudio/CodyPackage.cs
@@ -138,7 +138,8 @@ namespace Cody.VisualStudio
             NotificationHandlers.OnOptionsPageShowRequest += HandleOnOptionsPageShowRequest;
             ProgressNotificationHandlers = new ProgressNotificationHandlers(ProgressService);
 
-            WebView2Dev.InitializeController(ThemeService.GetThemingScript());
+            var sidebarController = WebView2Dev.InitializeController(ThemeService.GetThemingScript());
+            ThemeService.ThemeChanged += sidebarController.OnThemeChanged;
             NotificationHandlers.PostWebMessageAsJson = WebView2Dev.PostWebMessageAsJson;
 
             var runningDocumentTable = this.GetService<SVsRunningDocumentTable, IVsRunningDocumentTable>();

--- a/src/Cody.VisualStudio/Services/ThemeService.cs
+++ b/src/Cody.VisualStudio/Services/ThemeService.cs
@@ -35,7 +35,7 @@ namespace Cody.VisualStudio.Services
         {
             try
             {
-                await Task.Delay(100); // Short delay to allow VS to update colors
+                await Task.Delay(1000); // Short delay to allow VS to update colors
                 var latest = GetThemingScript();
                 ThemeChanged?.Invoke(this, new IColorThemeChangedEvent { ThemingScript = latest });
             }

--- a/src/Cody.VisualStudio/Services/ThemeService.cs
+++ b/src/Cody.VisualStudio/Services/ThemeService.cs
@@ -11,28 +11,38 @@ using System.Drawing;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
+using Cody.Core.Logging;
 
 namespace Cody.VisualStudio.Services
 {
     public class ThemeService : IThemeService
     {
-        private IServiceProvider serviceProvider;
+        private readonly IServiceProvider _serviceProvider;
+        private readonly ILog _logger;
 
         public event EventHandler<IColorThemeChangedEvent> ThemeChanged;
 
-        public ThemeService(IServiceProvider serviceProvider)
+        public ThemeService(IServiceProvider serviceProvider, ILog logger)
         {
-            this.serviceProvider = serviceProvider;
+            _serviceProvider = serviceProvider;
+            _logger = logger;
 
             VSColorTheme.ThemeChanged += HandleThemeChanges;
         }
 
 
-        private void HandleThemeChanges(ThemeChangedEventArgs e)
+        private async void HandleThemeChanges(ThemeChangedEventArgs e)
         {
-            Task.Delay(100).Wait(); // Short delay to allow VS to update colors
-            var latest = GetThemingScript();
-            ThemeChanged?.Invoke(this, new IColorThemeChangedEvent { ThemingScript = latest });
+            try
+            {
+                await Task.Delay(100); // Short delay to allow VS to update colors
+                var latest = GetThemingScript();
+                ThemeChanged?.Invoke(this, new IColorThemeChangedEvent { ThemingScript = latest });
+            }
+            catch (Exception ex)
+            {
+                _logger.Error("Processing VS Theme change failed.", ex);
+            }
         }
 
         public IReadOnlyDictionary<string, string> GetColors()
@@ -61,7 +71,7 @@ namespace Cody.VisualStudio.Services
 
         private FontInformation GetFontInfo(Guid categoryGuid)
         {
-            var storage = (IVsFontAndColorStorage)serviceProvider.GetService(typeof(SVsFontAndColorStorage));
+            var storage = (IVsFontAndColorStorage)_serviceProvider.GetService(typeof(SVsFontAndColorStorage));
             storage.OpenCategory(categoryGuid, (uint)(__FCSTORAGEFLAGS.FCSF_LOADDEFAULTS | __FCSTORAGEFLAGS.FCSF_READONLY));
 
             var logFont = new LOGFONTW[1];
@@ -80,7 +90,7 @@ namespace Cody.VisualStudio.Services
             const string darkTheme = "{1ded0138-47ce-435e-84ef-9ec1f439b749}";
             const string systemTheme = "{619dac1e-8220-4bd9-96fb-75ceb61a6107}";
 
-            var settingsManager = new ShellSettingsManager(serviceProvider);
+            var settingsManager = new ShellSettingsManager(_serviceProvider);
             var store = settingsManager.GetReadOnlySettingsStore(SettingsScope.UserSettings);
             var themeId = store.GetString("Theme", "BackupThemeId");
 

--- a/src/Cody.VisualStudio/Services/ThemeService.cs
+++ b/src/Cody.VisualStudio/Services/ThemeService.cs
@@ -1,4 +1,4 @@
-﻿using Cody.Core.Infrastructure;
+using Cody.Core.Infrastructure;
 using Microsoft.VisualStudio.PlatformUI;
 using Microsoft.VisualStudio.Settings;
 using Microsoft.VisualStudio.Shell;
@@ -10,6 +10,7 @@ using System.Diagnostics;
 using System.Drawing;
 using System.IO;
 using System.Text;
+using System.Threading.Tasks;
 
 namespace Cody.VisualStudio.Services
 {
@@ -17,12 +18,21 @@ namespace Cody.VisualStudio.Services
     {
         private IServiceProvider serviceProvider;
 
+        public event EventHandler<IColorThemeChangedEvent> ThemeChanged;
+
         public ThemeService(IServiceProvider serviceProvider)
         {
             this.serviceProvider = serviceProvider;
 
-            // TODO: Update the webviews when the theme changes.
-            // VSColorTheme.ThemeChanged += VSColorTheme_ThemeChanged;
+            VSColorTheme.ThemeChanged += HandleThemeChanges;
+        }
+
+
+        private void HandleThemeChanges(ThemeChangedEventArgs e)
+        {
+            Task.Delay(100).Wait(); // Short delay to allow VS to update colors
+            var latest = GetThemingScript();
+            ThemeChanged?.Invoke(this, new IColorThemeChangedEvent { ThemingScript = latest });
         }
 
         public IReadOnlyDictionary<string, string> GetColors()


### PR DESCRIPTION
CLOSE https://linear.app/sourcegraph/issue/CODY-3622/webview-theme-should-update-on-theme-changed

https://github.com/user-attachments/assets/4b388c44-456d-4a91-8a79-a594e51a56f9

Test Plan:

Try following the steps shown in the demo video above to switch theme and confirm the webview is updated accordingly.
