### PR TITLE
Dev: Fix cody dir name in Debug mode

### DIFF
--- a/src/Cody.UI/Controls/WebView2Dev.xaml.cs
+++ b/src/Cody.UI/Controls/WebView2Dev.xaml.cs
@@ -84,9 +84,11 @@ namespace Cody.UI.Controls
             try
             {
                 Logger?.Debug("Initializing ...");
-
-                var appData = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-                    "Cody");
+                var codyDir = "Cody";
+#if DEBUG
+                codyDir = "Cody\\Debug";
+#endif
+                var appData = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), codyDir);
                 var options = new CoreWebView2EnvironmentOptions
                 {
 #if DEBUG


### PR DESCRIPTION
CLOSE https://linear.app/sourcegraph/issue/CODY-3677/visual-studio-webview-fails-to-initialize

This fixes an issue where having Cody installed in your local machine will result in Cody not working in Debug mode.

This issue is caused by the app directory name being separated in production and debug mode.