### PR TITLE
Fixed Visual Studio not focused after auth redirection

### DIFF
--- a/src/Cody.Core/Agent/NotificationHandlers.cs
+++ b/src/Cody.Core/Agent/NotificationHandlers.cs
@@ -26,6 +26,7 @@ namespace Cody.Core.Agent
 
         public event EventHandler<string> OnRegisterWebViewRequest;
         public event EventHandler OnOptionsPageShowRequest;
+        public event EventHandler OnFocusSidebarRequest;
 
         public event EventHandler<AgentResponseEvent> OnPostMessageEvent;
 
@@ -211,6 +212,12 @@ namespace Cody.Core.Agent
         {
             _logger.Debug(key, $@"SecretDelete - {key}");
             _secretStorage.Delete(key);
+        }
+
+        [AgentCallback("window/focusSidebar")]
+        public void FocusSidebar(object param)
+        {
+            OnFocusSidebarRequest?.Invoke(this, EventArgs.Empty);
         }
     }
 }

--- a/src/Cody.VisualStudio.Tests/TestsBase.cs
+++ b/src/Cody.VisualStudio.Tests/TestsBase.cs
@@ -105,7 +105,7 @@ namespace Cody.VisualStudio.Tests
         protected async Task WaitForAsync(Func<bool> condition)
         {
             var startTime = DateTime.Now;
-            var timeout = TimeSpan.FromMinutes(2);
+            var timeout = TimeSpan.FromMinutes(5);
             while (!condition.Invoke())
             {
                 await Task.Delay(TimeSpan.FromSeconds(1));

--- a/src/Cody.VisualStudio/CodyPackage.cs
+++ b/src/Cody.VisualStudio/CodyPackage.cs
@@ -18,7 +18,6 @@ using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Connected.CredentialStorage;
-using Microsoft.VisualStudio.Shell.Events;
 using Microsoft.VisualStudio.Shell.Interop;
 using System;
 using System.Collections.Generic;
@@ -33,8 +32,11 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Threading;
 using Cody.UI.ViewModels;
+using EnvDTE;
+using EnvDTE80;
 using Task = System.Threading.Tasks.Task;
 using Microsoft.VisualStudio.TaskStatusCenter;
+using SolutionEvents = Microsoft.VisualStudio.Shell.Events.SolutionEvents;
 
 namespace Cody.VisualStudio
 {
@@ -141,6 +143,9 @@ namespace Cody.VisualStudio
             ProgressService = new ProgressService(statusCenterService);
             NotificationHandlers = new NotificationHandlers(UserSettingsService, AgentNotificationsLogger, FileService, SecretStorageService);
             NotificationHandlers.OnOptionsPageShowRequest += HandleOnOptionsPageShowRequest;
+            NotificationHandlers.OnFocusSidebarRequest += HandleOnFocusSidebarRequest;
+
+
             ProgressNotificationHandlers = new ProgressNotificationHandlers(ProgressService);
 
             var sidebarController = WebView2Dev.InitializeController(ThemeService.GetThemingScript(), Logger);
@@ -164,6 +169,22 @@ namespace Cody.VisualStudio
             catch (Exception ex)
             {
                 Logger.Error($"Navigation to '{nameof(GeneralOptionsPage)}' failed.", ex);
+            }
+        }
+
+        private void HandleOnFocusSidebarRequest(object sender, EventArgs e)
+        {
+            try
+            {
+                var dte = (DTE2)Package.GetGlobalService(typeof(DTE));
+                var mainWindow = dte.MainWindow;
+
+                mainWindow.Visible = true;
+                mainWindow.SetFocus();
+            }
+            catch (Exception ex)
+            {
+                Logger.Error("Failed.", ex);
             }
         }
 


### PR DESCRIPTION
CLOSE https://linear.app/sourcegraph/issue/CODY-3723/visual-studio-editor-not-focused-after-auth-redirection