### PR TITLE
Fixed visibility problem with "Loading Cody chat ..." when switching from and to the Tool Window

### DIFF
--- a/src/Cody.UI/Views/MainView.xaml
+++ b/src/Cody.UI/Views/MainView.xaml
@@ -15,13 +15,16 @@
              d:DesignWidth="400"
              >
     <Grid Background="Transparent">
+
         <TextBlock
             HorizontalAlignment="Center"
             VerticalAlignment="Center"
             TextAlignment="Center"
             Text="Loading Cody chat..."
+            Visibility="{Binding IsChatLoaded, Converter={x:Static converters:BooleanToVisibilityConverter.InvertedHidden}}"
             />
-            <controls:WebView2Dev 
+            <controls:WebView2Dev
+                Background="Transparent"
                 Html="{Binding Html}"
                 SendMessage="{Binding WebviewMessageSendCommand }"
                 PostMessage="{Binding PostMessage}"


### PR DESCRIPTION
CLOSE https://linear.app/sourcegraph/issue/CODY-3638/starting-debugger-would-cause-the-cody-webview-to-flash-the-loading

### Test Plan
1. Run Visual Studio and open Cody window
2. Switch to "Solution Explorer"
3. "Loading Cody chat ..." shouldn't be visible during switching between tabs