### PR TITLE
CI: Add cache for node_modules in CI

### DIFF
--- a/.github/workflows/cake-build.yml
+++ b/.github/workflows/cake-build.yml
@@ -23,9 +23,6 @@ jobs:
       - name: Install Cake.Tool
         run: dotnet tool install --global Cake.Tool
 
-      - name: Restore NuGet packages
-        run: nuget restore src\Cody.Core\Cody.Core.csproj -PackagesDirectory src\packages
-
       - name: Cache node_modules
         uses: actions/cache@v3
         with:
@@ -37,6 +34,7 @@ jobs:
       - name: PnpmInstall
         run: |
           cd src
+          dotnet tool restore
           dotnet cake --target=PnpmInstall
 
       - name: Build Release
@@ -44,7 +42,6 @@ jobs:
           cd src
           dotnet tool restore
           corepack enable
-          corepack install --global pnpm@8.6.7
           dotnet cake
 
       - name: Tests

--- a/.github/workflows/cake-build.yml
+++ b/.github/workflows/cake-build.yml
@@ -37,14 +37,6 @@ jobs:
       - name: Restore NuGet packages
         run: nuget restore src\Cody.Core\Cody.Core.csproj -PackagesDirectory src\packages
 
-      - name: Cache cody-dist
-        uses: actions/cache@v3
-        with:
-          path: cody-dist
-          key: ${{ runner.os }}-cody-dist-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-cody-dist-
-
       - name: Common Build Setup
         run: |
           cd src
@@ -55,7 +47,7 @@ jobs:
         run: |
           cd src
           corepack install --global pnpm@8.6.7
-          dotnet cake --target=BuildCodyAgentIfNeeded
+          dotnet cake --target=BuildCodyAgent
 
       - name: Build & Tests
         env:

--- a/.github/workflows/cake-build.yml
+++ b/.github/workflows/cake-build.yml
@@ -37,13 +37,13 @@ jobs:
       - name: Restore NuGet packages
         run: nuget restore src\Cody.Core\Cody.Core.csproj -PackagesDirectory src\packages
 
-      - name: Cache node_modules
+      - name: Cache cody-dist
         uses: actions/cache@v3
         with:
-          path: cody-dist/agent/node_modules
-          key: ${{ runner.os }}-node-${{ hashFiles('**/pnpm-lock.yaml') }}
+          path: cody-dist
+          key: ${{ runner.os }}-cody-dist-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-node-
+            ${{ runner.os }}-cody-dist-
 
       - name: Common Build Setup
         run: |
@@ -51,11 +51,11 @@ jobs:
           dotnet tool restore
           corepack enable
 
-      - name: Build Cody Agent
+      - name: Build Cody Agent if needed
         run: |
           cd src
           corepack install --global pnpm@8.6.7
-          dotnet cake --target=BuildCodyAgent
+          dotnet cake --target=BuildCodyAgentIfNeeded
 
       - name: Build Extension
         run: |

--- a/.github/workflows/cake-build.yml
+++ b/.github/workflows/cake-build.yml
@@ -23,26 +23,33 @@ jobs:
       - name: Install Cake.Tool
         run: dotnet tool install --global Cake.Tool
 
+      - name: Restore NuGet packages
+        run: nuget restore src\Cody.Core\Cody.Core.csproj -PackagesDirectory src\packages
+
       - name: Cache node_modules
         uses: actions/cache@v3
         with:
-          path: src/cody/agent/node_modules
+          path: cody-dist/agent/node_modules
           key: ${{ runner.os }}-node-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-node-
 
-      - name: PnpmInstall
-        run: |
-          cd src
-          dotnet tool restore
-          dotnet cake --target=PnpmInstall
-
-      - name: Build Release
+      - name: Common Build Setup
         run: |
           cd src
           dotnet tool restore
           corepack enable
-          dotnet cake
+
+      - name: Build Cody Agent
+        run: |
+          cd src
+          corepack install --global pnpm@8.6.7
+          dotnet cake --target=BuildCodyAgent
+
+      - name: Build Extension
+        run: |
+          cd src
+          dotnet cake --target=BuildExtension
 
       - name: Tests
         env:

--- a/.github/workflows/cake-build.yml
+++ b/.github/workflows/cake-build.yml
@@ -2,9 +2,9 @@
 
 on:
   push:
-    branches: [main]
+    branches: [ main ]
   pull_request:
-    branches: [main]
+    branches: [ main ]
   workflow_dispatch:
 
 # concurrency prevents multiple instances of the workflow from running at the same time,

--- a/.github/workflows/cake-build.yml
+++ b/.github/workflows/cake-build.yml
@@ -57,15 +57,10 @@ jobs:
           corepack install --global pnpm@8.6.7
           dotnet cake --target=BuildCodyAgentIfNeeded
 
-      - name: Build Extension
-        run: |
-          cd src
-          dotnet cake --target=BuildExtension
-
-      - name: Tests
+      - name: Build & Tests
         env:
           Access_Token_UI_Tests: ${{ secrets.SRC_ACCESS_TOKEN_DOTCOM }}
         run: |
           cd src
-          dotnet cake --target Tests
+          dotnet cake --target=BuildDebug
           dotnet test .\Cody.VisualStudio.Tests\bin\Debug\Cody.VisualStudio.Tests.dll -v detailed

--- a/.github/workflows/cake-build.yml
+++ b/.github/workflows/cake-build.yml
@@ -1,4 +1,4 @@
-﻿name: Cake Build
+﻿﻿name: Cake Build
 
 on:
   push:
@@ -37,22 +37,34 @@ jobs:
       - name: Restore NuGet packages
         run: nuget restore src\Cody.Core\Cody.Core.csproj -PackagesDirectory src\packages
 
+      - name: Cache Cody Agent build
+        uses: actions/cache@v3
+        with:
+          path: cody-dist/agent
+          key: ${{ runner.os }}-cody-dist-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-cody-dist-
+
       - name: Common Build Setup
         run: |
           cd src
           dotnet tool restore
           corepack enable
 
-      - name: Build Cody Agent if needed
+      - name: Build Cody Agent
         run: |
           cd src
           corepack install --global pnpm@8.6.7
           dotnet cake --target=BuildCodyAgent
 
-      - name: Build & Tests
+      - name: Build Extension & Tests
+        run: |
+          cd src
+          dotnet cake --target=BuildDebug
+
+      - name: Run Tests
         env:
           Access_Token_UI_Tests: ${{ secrets.SRC_ACCESS_TOKEN_DOTCOM }}
         run: |
           cd src
-          dotnet cake --target=BuildDebug
           dotnet test .\Cody.VisualStudio.Tests\bin\Debug\Cody.VisualStudio.Tests.dll -v detailed

--- a/.github/workflows/cake-build.yml
+++ b/.github/workflows/cake-build.yml
@@ -2,9 +2,9 @@
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
   workflow_dispatch:
 
 jobs:
@@ -12,32 +12,45 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-    - name: Add msbuild to PATH
-      uses: microsoft/setup-msbuild@v1.3
+      - name: Add msbuild to PATH
+        uses: microsoft/setup-msbuild@v1.3
 
-    - name: ⚙️ Prepare Visual Studio
-      run: '&"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\devenv.exe" /RootSuffix Exp /ResetSettings General.vssettings'
+      - name: ⚙️ Prepare Visual Studio
+        run: '&"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\devenv.exe" /RootSuffix Exp /ResetSettings General.vssettings'
 
-    - name: Install Cake.Tool
-      run: dotnet tool install --global Cake.Tool
+      - name: Install Cake.Tool
+        run: dotnet tool install --global Cake.Tool
 
-    - name: Restore NuGet packages
-      run: nuget restore src\Cody.Core\Cody.Core.csproj -PackagesDirectory src\packages
+      - name: Restore NuGet packages
+        run: nuget restore src\Cody.Core\Cody.Core.csproj -PackagesDirectory src\packages
 
-    - name: Build Release
-      run: |
-        cd src
-        dotnet tool restore
-        corepack enable
-        corepack install --global pnpm@8.6.7
-        dotnet cake
+      - name: Cache node_modules
+        uses: actions/cache@v3
+        with:
+          path: src/cody/agent/node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
 
-    - name: Tests
-      env: 
-        Access_Token_UI_Tests: ${{ secrets.SRC_ACCESS_TOKEN_DOTCOM }}
-      run: |
-        cd src
-        dotnet cake --target Tests
-        dotnet test .\Cody.VisualStudio.Tests\bin\Debug\Cody.VisualStudio.Tests.dll -v detailed
+      - name: PnpmInstall
+        run: |
+          cd src
+          dotnet cake --target=PnpmInstall
+
+      - name: Build Release
+        run: |
+          cd src
+          dotnet tool restore
+          corepack enable
+          corepack install --global pnpm@8.6.7
+          dotnet cake
+
+      - name: Tests
+        env:
+          Access_Token_UI_Tests: ${{ secrets.SRC_ACCESS_TOKEN_DOTCOM }}
+        run: |
+          cd src
+          dotnet cake --target Tests
+          dotnet test .\Cody.VisualStudio.Tests\bin\Debug\Cody.VisualStudio.Tests.dll -v detailed

--- a/.github/workflows/cake-build.yml
+++ b/.github/workflows/cake-build.yml
@@ -2,9 +2,11 @@
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
   workflow_dispatch:
 
 # concurrency prevents multiple instances of the workflow from running at the same time,
@@ -55,12 +57,12 @@ jobs:
         run: |
           cd src
           corepack install --global pnpm@8.6.7
-          dotnet cake --target=BuildCodyAgent
+          dotnet cake --target BuildCodyAgent
 
       - name: Build Extension & Tests
         run: |
           cd src
-          dotnet cake --target=BuildDebug
+          dotnet cake --target DebugBuild
 
       - name: Run Tests
         env:

--- a/.github/workflows/cake-build.yml
+++ b/.github/workflows/cake-build.yml
@@ -7,9 +7,20 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# concurrency prevents multiple instances of the workflow from running at the same time,
+# using `cancel-in-progress` to cancel any existing runs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
-    runs-on: windows-latest
+    # this now uses a dedicated large runner from GitHub running the following specs:
+    # 8-core, 32GB RAM, 300GB SSD
+    # https://github.com/organizations/sourcegraph/settings/actions/runner-groups/6
+    runs-on: 16gb_16_core_large_window_runner
+    # do we want to run this on forks?
+    if: github.repository_owner == 'sourcegraph'
 
     steps:
       - uses: actions/checkout@v3

--- a/src/build.cake
+++ b/src/build.cake
@@ -148,7 +148,6 @@ Task("BuildCodyAgent")
 
 });
 
-
 Task("DownloadNode")
 	.Does(() =>
 {
@@ -182,19 +181,6 @@ Task("Build")
 	});
 });
 
-Task("BuildExtension")
-	.IsDependentOn("DownloadNode")
-	.IsDependentOn("Restore")
-	.Does(() =>
-{
-	MSBuild("./Cody.sln", new MSBuildSettings
-	{
-		Configuration = configuration,
-		PlatformTarget = PlatformTarget.MSIL,
-		Verbosity = Verbosity.Minimal
-	});
-});
-
 Task("BuildDebug")
 	.IsDependentOn("DownloadNode")
 	.IsDependentOn("Restore")
@@ -203,20 +189,27 @@ Task("BuildDebug")
 	MSBuild("./Cody.sln", new MSBuildSettings
 	{
 		Configuration = "Debug",
-		PlatformTarget = PlatformTarget.MSIL,
+        PlatformTarget = PlatformTarget.MSIL,
 		Verbosity = Verbosity.Minimal
 	});
 });
 
 Task("Tests")
+	//.IsDependentOn("Build")
 	.Does(() =>
 {
 	MSBuild("./Cody.sln", new MSBuildSettings
 	{
 		Configuration = "Debug",
-		PlatformTarget = PlatformTarget.MSIL,
+        PlatformTarget = PlatformTarget.MSIL,
 		Verbosity = Verbosity.Minimal
 	});
+
+//	DotNetTest("./Cody.VisualStudio.Tests/bin/Debug/Cody.VisualStudio.Tests.dll", new DotNetTestSettings 
+//    {
+//        NoBuild = true,
+//        NoRestore = true
+//    });
 });
 
 Task("Restore")

--- a/src/build.cake
+++ b/src/build.cake
@@ -210,22 +210,28 @@ Task("BuildExtension")
 	});
 });
 
-Task("Tests")
-	//.IsDependentOn("Build")
+Task("BuildDebug")
+	.IsDependentOn("DownloadNode")
+	.IsDependentOn("Restore")
 	.Does(() =>
 {
 	MSBuild("./Cody.sln", new MSBuildSettings
 	{
 		Configuration = "Debug",
-        PlatformTarget = PlatformTarget.MSIL,
+		PlatformTarget = PlatformTarget.MSIL,
 		Verbosity = Verbosity.Minimal
 	});
+});
 
-//	DotNetTest("./Cody.VisualStudio.Tests/bin/Debug/Cody.VisualStudio.Tests.dll", new DotNetTestSettings 
-//    {
-//        NoBuild = true,
-//        NoRestore = true
-//    });
+Task("Tests")
+	.Does(() =>
+{
+	MSBuild("./Cody.sln", new MSBuildSettings
+	{
+		Configuration = "Debug",
+		PlatformTarget = PlatformTarget.MSIL,
+		Verbosity = Verbosity.Minimal
+	});
 });
 
 Task("Restore")

--- a/src/build.cake
+++ b/src/build.cake
@@ -148,21 +148,6 @@ Task("BuildCodyAgent")
 
 });
 
-Task("BuildCodyAgentIfNeeded")
-    .Does(() =>
-{
-    var codyAgentDistDir = MakeAbsolute(codyDir + Directory("agent/dist"));
-    if (!DirectoryExists(codyAgentDistDir))
-    {
-        Information("Cody Agent dist directory not found. Building Cody Agent...");
-        RunTarget("BuildCodyAgent");
-    }
-    else
-    {
-        Information("Cody Agent dist directory already exists. Skipping build.");
-    }
-});
-
 
 Task("DownloadNode")
 	.Does(() =>

--- a/src/build.cake
+++ b/src/build.cake
@@ -54,7 +54,20 @@ var marketplaceToken = EnvironmentVariable("CODY_VS_MARKETPLACE_RELEASE_TOKEN");
 // TASKS
 //////////////////////////////////////////////////////////////////////
 
+Task("PnpmInstall")
+    .Does(() =>
+{
+    var codyAgentDir = MakeAbsolute(codyDir + Directory("agent"));
+    Context.Environment.WorkingDirectory = codyAgentDir;
+
+    Information($"--> pnpm install ...");
+    PnpmInstall();
+
+    Context.Environment.WorkingDirectory = solutionDir;
+});
+
 Task("BuildCodyAgent")
+    .IsDependentOn("PnpmInstall")
 	.Does(() =>
 {
 
@@ -100,9 +113,6 @@ Task("BuildCodyAgent")
 	CleanDirectory(codyAgentDistDir);
 
 	Context.Environment.WorkingDirectory = codyAgentDir;
-
-	Information($"--> pnpm install ...");
-	PnpmInstall();
 
 	Information($"--> pnpm build ...");
 	PnpmRun("build");

--- a/src/build.cake
+++ b/src/build.cake
@@ -46,7 +46,8 @@ var codyRepo = "https://github.com/sourcegraph/cody.git";
 var nodeBinaryUrl = "https://github.com/sourcegraph/node-binaries/raw/main/v20.12.2/node-win-x64.exe";
 var nodeArmBinaryUrl = "https://github.com/sourcegraph/node-binaries/raw/main/v20.12.2/node-win-arm64.exe";
 
-var codyCommit = "503154d7b220be0ebcfff5d58e6348293a98ff63"; // points to https://github.com/sourcegraph/cody/pull/5532 in the main branch
+// The latest tag of the stable release from the cody repository https://github.com/sourcegraph/cody/tags
+var codyStableReleaseTag = "vscode-v1.34.3";
 
 var marketplaceToken = EnvironmentVariable("CODY_VS_MARKETPLACE_RELEASE_TOKEN");
 
@@ -54,20 +55,7 @@ var marketplaceToken = EnvironmentVariable("CODY_VS_MARKETPLACE_RELEASE_TOKEN");
 // TASKS
 //////////////////////////////////////////////////////////////////////
 
-Task("PnpmInstall")
-    .Does(() =>
-{
-    var codyAgentDir = MakeAbsolute(codyDir + Directory("agent"));
-    Context.Environment.WorkingDirectory = codyAgentDir;
-
-    Information($"--> pnpm install ...");
-    PnpmInstall();
-
-    Context.Environment.WorkingDirectory = solutionDir;
-});
-
 Task("BuildCodyAgent")
-    .IsDependentOn("PnpmInstall")
 	.Does(() =>
 {
 
@@ -105,14 +93,20 @@ Task("BuildCodyAgent")
 		Information($"--> Checkout '{branchName}' ...");
 		GitCheckout(codyDir, branchName);
 
-        Information($"--> Checkout '{branchName}' using commit {codyCommit} ...");
-		GitCheckout(codyDir, codyCommit);
+        Information($"--> Fetching all tags...");
+        GitFetch(codyDir, "origin");
+
+        Information($"--> Checkout latest stable release using tag {codyStableReleaseTag} ...");
+		GitCheckout(codyDir, codyStableReleaseTag);
 	}
 
 	Information($"--> Cleaning '{codyAgentDistDir}' ...");
 	CleanDirectory(codyAgentDistDir);
 
 	Context.Environment.WorkingDirectory = codyAgentDir;
+
+	Information($"--> pnpm install ...");
+	PnpmInstall();
 
 	Information($"--> pnpm build ...");
 	PnpmRun("build");
@@ -175,6 +169,19 @@ Task("DownloadNode")
 
 Task("Build")
 	.IsDependentOn("BuildCodyAgent")
+	.IsDependentOn("DownloadNode")
+	.IsDependentOn("Restore")
+	.Does(() =>
+{
+	MSBuild("./Cody.sln", new MSBuildSettings
+	{
+		Configuration = configuration,
+		PlatformTarget = PlatformTarget.MSIL,
+		Verbosity = Verbosity.Minimal
+	});
+});
+
+Task("BuildExtension")
 	.IsDependentOn("DownloadNode")
 	.IsDependentOn("Restore")
 	.Does(() =>

--- a/src/build.cake
+++ b/src/build.cake
@@ -148,6 +148,22 @@ Task("BuildCodyAgent")
 
 });
 
+Task("BuildCodyAgentIfNeeded")
+    .Does(() =>
+{
+    var codyAgentDistDir = MakeAbsolute(codyDir + Directory("agent/dist"));
+    if (!DirectoryExists(codyAgentDistDir))
+    {
+        Information("Cody Agent dist directory not found. Building Cody Agent...");
+        RunTarget("BuildCodyAgent");
+    }
+    else
+    {
+        Information("Cody Agent dist directory already exists. Skipping build.");
+    }
+});
+
+
 Task("DownloadNode")
 	.Does(() =>
 {

--- a/src/build.cake
+++ b/src/build.cake
@@ -181,7 +181,7 @@ Task("Build")
 	});
 });
 
-Task("BuildDebug")
+Task("DebugBuild")
 	.IsDependentOn("DownloadNode")
 	.IsDependentOn("Restore")
 	.Does(() =>


### PR DESCRIPTION
- Add cache for node_modules in the CI workflow
- Move pnpm install to a separate task to leverage the cache

These changes will:

Create a separate "PnpmInstall" task in the build.cake file. Make "BuildCodyAgent" depend on "PnpmInstall".
Add a caching step for node_modules in the GitHub Actions workflow. Run the "PnpmInstall" task separately before the main build. This setup will cache the node_modules directory based on the pnpm-lock.yaml file hash. If the lock file hasn't changed, it will use the cached node_modules, significantly speeding up the build process.