### PR TITLE
CI: use caching and split Build and Tests step

### DIFF
--- a/.github/workflows/cake-build.yml
+++ b/.github/workflows/cake-build.yml
@@ -2,42 +2,69 @@
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
   workflow_dispatch:
+
+# concurrency prevents multiple instances of the workflow from running at the same time,
+# using `cancel-in-progress` to cancel any existing runs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
-    runs-on: windows-latest
+    # this now uses a dedicated large runner from GitHub running the following specs:
+    # 8-core, 32GB RAM, 300GB SSD
+    # https://github.com/organizations/sourcegraph/settings/actions/runner-groups/6
+    runs-on: 16gb_16_core_large_window_runner
+    # do we want to run this on forks?
+    if: github.repository_owner == 'sourcegraph'
 
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-    - name: Add msbuild to PATH
-      uses: microsoft/setup-msbuild@v1.3
+      - name: Add msbuild to PATH
+        uses: microsoft/setup-msbuild@v1.3
 
-    - name: ⚙️ Prepare Visual Studio
-      run: '&"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\devenv.exe" /RootSuffix Exp /ResetSettings General.vssettings'
+      - name: ⚙️ Prepare Visual Studio
+        run: '&"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\devenv.exe" /RootSuffix Exp /ResetSettings General.vssettings'
 
-    - name: Install Cake.Tool
-      run: dotnet tool install --global Cake.Tool
+      - name: Install Cake.Tool
+        run: dotnet tool install --global Cake.Tool
 
-    - name: Restore NuGet packages
-      run: nuget restore src\Cody.Core\Cody.Core.csproj -PackagesDirectory src\packages
+      - name: Restore NuGet packages
+        run: nuget restore src\Cody.Core\Cody.Core.csproj -PackagesDirectory src\packages
 
-    - name: Build Release
-      run: |
-        cd src
-        dotnet tool restore
-        corepack enable
-        corepack install --global pnpm@8.6.7
-        dotnet cake
+      - name: Cache cody-dist
+        uses: actions/cache@v3
+        with:
+          path: cody-dist/agent
+          key: ${{ runner.os }}-cody-dist-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-cody-dist-
 
-    - name: Tests
-      env: 
-        Access_Token_UI_Tests: ${{ secrets.SRC_ACCESS_TOKEN_DOTCOM }}
-      run: |
-        cd src
-        dotnet cake --target Tests
-        dotnet test .\Cody.VisualStudio.Tests\bin\Debug\Cody.VisualStudio.Tests.dll -v detailed
+      - name: Common Build Setup
+        run: |
+          cd src
+          dotnet tool restore
+          corepack enable
+
+      - name: Build Cody Agent
+        run: |
+          cd src
+          corepack install --global pnpm@8.6.7
+          dotnet cake --target=BuildCodyAgent
+
+      - name: Build Extension
+        run: |
+          cd src
+          dotnet cake --target=BuildDebug
+
+      - name: Tests
+        env:
+          Access_Token_UI_Tests: ${{ secrets.SRC_ACCESS_TOKEN_DOTCOM }}
+        run: |
+          cd src
+          dotnet test .\Cody.VisualStudio.Tests\bin\Debug\Cody.VisualStudio.Tests.dll -v detailed

--- a/.github/workflows/cake-build.yml
+++ b/.github/workflows/cake-build.yml
@@ -57,7 +57,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cody-dist-
 
-      - name: Build Extension
+      - name: Build Extension (Debug)
         run: |
           cd src
           dotnet cake --target=BuildDebug

--- a/.github/workflows/cake-build.yml
+++ b/.github/workflows/cake-build.yml
@@ -37,14 +37,6 @@ jobs:
       - name: Restore NuGet packages
         run: nuget restore src\Cody.Core\Cody.Core.csproj -PackagesDirectory src\packages
 
-      - name: Cache cody-dist
-        uses: actions/cache@v3
-        with:
-          path: cody-dist/agent
-          key: ${{ runner.os }}-cody-dist-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-cody-dist-
-
       - name: Common Build Setup
         run: |
           cd src
@@ -56,6 +48,14 @@ jobs:
           cd src
           corepack install --global pnpm@8.6.7
           dotnet cake --target=BuildCodyAgentIfNeeded
+
+      - name: Cache cody-dist
+        uses: actions/cache@v3
+        with:
+          path: cody-dist/agent
+          key: ${{ runner.os }}-cody-dist-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-cody-dist-
 
       - name: Build Extension
         run: |

--- a/.github/workflows/cake-build.yml
+++ b/.github/workflows/cake-build.yml
@@ -51,11 +51,11 @@ jobs:
           dotnet tool restore
           corepack enable
 
-      - name: Build Cody Agent
+      - name: Build Cody Agent if needed
         run: |
           cd src
           corepack install --global pnpm@8.6.7
-          dotnet cake --target=BuildCodyAgent
+          dotnet cake --target=BuildCodyAgentIfNeeded
 
       - name: Build Extension
         run: |

--- a/.github/workflows/cake-build.yml
+++ b/.github/workflows/cake-build.yml
@@ -67,4 +67,4 @@ jobs:
           Access_Token_UI_Tests: ${{ secrets.SRC_ACCESS_TOKEN_DOTCOM }}
         run: |
           cd src
-          dotnet test .\Cody.VisualStudio.Tests\bin\Debug\Cody.VisualStudio.Tests.dll -v detailed
+          dotnet test .\Cody.VisualStudio.Tests\bin\Debug\Cody.VisualStudio.Tests.dll -v detailed --parallel

--- a/src/build.cake
+++ b/src/build.cake
@@ -181,6 +181,19 @@ Task("Build")
 	});
 });
 
+Task("BuildDebug")
+	.IsDependentOn("DownloadNode")
+	.IsDependentOn("Restore")
+	.Does(() =>
+{
+	MSBuild("./Cody.sln", new MSBuildSettings
+	{
+		Configuration = "Debug",
+        PlatformTarget = PlatformTarget.MSIL,
+		Verbosity = Verbosity.Minimal
+	});
+});
+
 Task("Tests")
 	//.IsDependentOn("Build")
 	.Does(() =>

--- a/src/build.cake
+++ b/src/build.cake
@@ -148,6 +148,21 @@ Task("BuildCodyAgent")
 
 });
 
+Task("BuildCodyAgentIfNeeded")
+    .Does(() =>
+{
+    var codyAgentDistDir = MakeAbsolute(codyDir + Directory("agent/dist"));
+    if (!DirectoryExists(codyAgentDistDir))
+    {
+        Information("Cody Agent dist directory not found. Building Cody Agent...");
+        RunTarget("BuildCodyAgent");
+    }
+    else
+    {
+        Information("Cody Agent dist directory already exists. Skipping build.");
+    }
+});
+
 Task("DownloadNode")
 	.Does(() =>
 {

--- a/src/build.cake
+++ b/src/build.cake
@@ -151,7 +151,7 @@ Task("BuildCodyAgent")
 Task("BuildCodyAgentIfNeeded")
     .Does(() =>
 {
-    if (!DirectoryExists(codyDir))
+    if (!DirectoryExists(codyDir) || !DirectoryExists(agentDir))
     {
         Information("Cody Agent dist directory not found. Building Cody Agent...");
         RunTarget("BuildCodyAgent");

--- a/src/build.cake
+++ b/src/build.cake
@@ -151,7 +151,7 @@ Task("BuildCodyAgent")
 Task("BuildCodyAgentIfNeeded")
     .Does(() =>
 {
-    if (!DirectoryExists(agentDir))
+    if (!DirectoryExists(codyDir))
     {
         Information("Cody Agent dist directory not found. Building Cody Agent...");
         RunTarget("BuildCodyAgent");

--- a/src/build.cake
+++ b/src/build.cake
@@ -151,8 +151,7 @@ Task("BuildCodyAgent")
 Task("BuildCodyAgentIfNeeded")
     .Does(() =>
 {
-    var codyAgentDistDir = MakeAbsolute(codyDir + Directory("agent/dist"));
-    if (!DirectoryExists(codyAgentDistDir))
+    if (!DirectoryExists(agentDir))
     {
         Information("Cody Agent dist directory not found. Building Cody Agent...");
         RunTarget("BuildCodyAgent");


### PR DESCRIPTION
CLOSE https://linear.app/sourcegraph/issue/CODY-3944/cake-build-github-action-takes-at-least-40-mins-to-complete

Discussion with @BolajiOlajide in https://sourcegraph.slack.com/archives/C04MYFW01NV/p1727732199068899

Attempt to improve CI by:
- use caching
- split Build and Tests step
- increase instance resources