### PR TITLE
Fetch tags before trying to check them out

### DIFF
--- a/src/build.cake
+++ b/src/build.cake
@@ -94,7 +94,7 @@ Task("BuildCodyAgent")
 		GitCheckout(codyDir, branchName);
 
         Information($"--> Fetching all tags...");
-        GitFetch(codyDir, "origin");
+        GitFetchTags(codyDir, "origin");
 
         Information($"--> Checkout latest stable release using tag {codyStableReleaseTag} ...");
 		GitCheckout(codyDir, codyStableReleaseTag);


### PR DESCRIPTION
`build.cake` fails if you have a Cody repo cloned, but have not fetched the stable release tag. This is because `GitFetch` does not fetch tags. Use `GitFetchTags` instead.

# Test plan

Delete the current Cody commit tag, and run `dotnet cake`.

```
cd ../cody-dist
git tags -d vscode-v1.34.3
cd ../src
dotnet cake
```