### PR TITLE
Dev: Allow specifying Cody branch or tag to build agent

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,63 @@
+name: Nightly Build
+
+on:
+  schedule:
+    - cron: "0 2 * * *" # Runs at 2 AM UTC every day
+  workflow_dispatch: # Allows manual triggering
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: 16gb_16_core_large_window_runner
+    if: github.repository_owner == 'sourcegraph'
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Add msbuild to PATH
+        uses: microsoft/setup-msbuild@v1.3
+
+      - name: ⚙️ Prepare Visual Studio
+        run: '&"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\devenv.exe" /RootSuffix Exp /ResetSettings General.vssettings'
+
+      - name: Install Cake.Tool
+        run: dotnet tool install --global Cake.Tool
+
+      - name: Restore NuGet packages
+        run: nuget restore src\Cody.Core\Cody.Core.csproj -PackagesDirectory src\packages
+
+      - name: Common Build Setup
+        run: |
+          cd src
+          dotnet tool restore
+          corepack enable
+
+      - name: Build Cody Agent (main branch)
+        run: |
+          cd src
+          corepack install --global pnpm@8.6.7
+          dotnet cake --target=BuildCodyAgent --cody-branch=main
+
+      - name: Build Extension (Debug)
+        run: |
+          cd src
+          dotnet cake --target=BuildDebug
+
+      - name: Tests
+        env:
+          Access_Token_UI_Tests: ${{ secrets.SRC_ACCESS_TOKEN_DOTCOM }}
+        run: |
+          cd src
+          dotnet test .\Cody.VisualStudio.Tests\bin\Debug\Cody.VisualStudio.Tests.dll -v detailed -l:trx
+
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action/windows@v2
+        if: always()
+        with:
+          files: |
+            src\TestResults/**/*.xml
+            src\TestResults/**/*.trx
+            src\TestResults/**/*.json

--- a/src/build.cake
+++ b/src/build.cake
@@ -5,7 +5,6 @@
 var target = Argument("target", "Build");
 var configuration = Argument("configuration", "Release");
 
-
 var agentDir = Directory("./Cody.VisualStudio/Agent");
 var agentWebViewDir = agentDir + Directory("webviews");
 var codyDevDir = Directory("../../cody");
@@ -48,6 +47,7 @@ var nodeArmBinaryUrl = "https://github.com/sourcegraph/node-binaries/raw/main/v2
 
 // The latest tag of the stable release from the cody repository https://github.com/sourcegraph/cody/tags
 var codyStableReleaseTag = "vscode-v1.34.3";
+var codyBranch = Argument("cody-branch", codyStableReleaseTag);
 
 var marketplaceToken = EnvironmentVariable("CODY_VS_MARKETPLACE_RELEASE_TOKEN");
 
@@ -96,8 +96,8 @@ Task("BuildCodyAgent")
         Information($"--> Fetching all tags...");
         GitFetchTags(codyDir, "origin");
 
-        Information($"--> Checkout latest stable release using tag {codyStableReleaseTag} ...");
-		GitCheckout(codyDir, codyStableReleaseTag);
+        Information($"--> Checkout specified branch or tag: {codyBranch} ...");
+        GitCheckout(codyDir, codyBranch);
 	}
 
 	Information($"--> Cleaning '{codyAgentDistDir}' ...");

--- a/src/build.cake
+++ b/src/build.cake
@@ -46,7 +46,7 @@ var nodeBinaryUrl = "https://github.com/sourcegraph/node-binaries/raw/main/v20.1
 var nodeArmBinaryUrl = "https://github.com/sourcegraph/node-binaries/raw/main/v20.12.2/node-win-arm64.exe";
 
 // The latest tag of the stable release from the cody repository https://github.com/sourcegraph/cody/tags
-var codyStableReleaseTag = "vscode-v1.34.3";
+var codyStableReleaseTag = "vscode-v1.38.1";
 var codyBranch = Argument("cody-branch", codyStableReleaseTag);
 
 var marketplaceToken = EnvironmentVariable("CODY_VS_MARKETPLACE_RELEASE_TOKEN");


### PR DESCRIPTION
CLOSE: https://linear.app/sourcegraph/issue/CODY-4069/run-build-off-cody-main-nightly-for-visual-studio

This change allows specifying the Cody branch or tag to use when building the Cody agent, instead of always using the latest stable release tag.

The `cody-branch` argument has been added to the `BuildCodyAgent` task, which defaults to the latest stable release tag (`vscode-v1.38.1`) if not provided.

This provides more flexibility in building the agent, allowing developers to test against specific Cody branches or tags as needed.
