### PR TITLE
Custom configuration support

### DIFF
--- a/src/Cody.Core/Agent/Protocol/ExtensionConfiguration.cs
+++ b/src/Cody.Core/Agent/Protocol/ExtensionConfiguration.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace Cody.Core.Agent.Protocol
 {
     public class ExtensionConfiguration
@@ -17,6 +19,9 @@ namespace Cody.Core.Agent.Protocol
         public bool VerboseDebug { get; set; }
 
         public string Codebase { get; set; }
+
+        public Dictionary<string, object> CustomConfiguration { get; set; }
+
 
         public override string ToString()
         {

--- a/src/Cody.Core/Cody.Core.csproj
+++ b/src/Cody.Core/Cody.Core.csproj
@@ -86,6 +86,8 @@
     <Compile Include="Agent\WebviewMessageHandler.cs" />
     <Compile Include="DocumentSync\DocumentSyncCallback.cs" />
     <Compile Include="DocumentSync\IDocumentSyncActions.cs" />
+    <Compile Include="Infrastructure\ConfigurationService.cs" />
+    <Compile Include="Infrastructure\IConfigurationService.cs" />
     <Compile Include="Infrastructure\ISecretStorageService.cs" />
     <Compile Include="Infrastructure\IProgressService.cs" />
     <Compile Include="Logging\ITestLogger.cs" />

--- a/src/Cody.Core/Infrastructure/ConfigurationService.cs
+++ b/src/Cody.Core/Infrastructure/ConfigurationService.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Collections.Generic;
+using Cody.Core.Agent.Protocol;
+using Cody.Core.Ide;
+using Cody.Core.Inf;
+using Cody.Core.Logging;
+using Cody.Core.Settings;
+using Newtonsoft.Json;
+
+namespace Cody.Core.Infrastructure
+{
+    public class ConfigurationService : IConfigurationService
+    {
+        private readonly IVersionService _versionService;
+        private readonly IVsVersionService _vsVersionService;
+        private readonly ISolutionService _solutionService;
+        private readonly IUserSettingsService _userSettingsService;
+        private readonly ILog _logger;
+
+        public ConfigurationService(IVersionService versionService, IVsVersionService vsVersionService, ISolutionService solutionService, IUserSettingsService userSettingsService, ILog logger)
+        {
+            _versionService = versionService;
+            _vsVersionService = vsVersionService;
+            _solutionService = solutionService;
+            _userSettingsService = userSettingsService;
+            _logger = logger;
+        }
+
+        public ClientInfo GetClientInfo()
+        {
+            var clientInfo = new ClientInfo
+            {
+                Name = "VisualStudio",
+                Version = _versionService.Full,
+                IdeVersion = _vsVersionService.Version.ToString(),
+                WorkspaceRootUri = _solutionService.GetSolutionDirectory(),
+                Capabilities = new ClientCapabilities
+                {
+                    Authentication = Capability.Enabled,
+                    Completions = "none",
+                    Edit = Capability.None,
+                    EditWorkspace = Capability.None,
+                    ProgressBars = Capability.Enabled,
+                    CodeLenses = Capability.None,
+                    ShowDocument = Capability.Enabled,
+                    Ignore = Capability.Enabled,
+                    UntitledDocuments = Capability.None,
+                    Webview = "native",
+                    WebviewNativeConfig = new WebviewCapabilities
+                    {
+                        View = WebviewView.Single,
+                        CspSource = "'self' https://cody.vs",
+                        WebviewBundleServingPrefix = "https://cody.vs",
+                    },
+                    WebviewMessages = "string-encoded",
+                    GlobalState = "server-managed",
+                    Secrets = "client-managed",
+                },
+                ExtensionConfiguration = GetConfiguration()
+            };
+
+            return clientInfo;
+        }
+
+        public ExtensionConfiguration GetConfiguration()
+        {
+            var config = new ExtensionConfiguration
+            {
+                AnonymousUserID = _userSettingsService.AnonymousUserID,
+                ServerEndpoint = _userSettingsService.ServerEndpoint,
+                Proxy = null,
+                AccessToken = _userSettingsService.AccessToken,
+                AutocompleteAdvancedProvider = null,
+                Debug = true,
+                VerboseDebug = true,
+                CustomConfiguration = GetCustomConfiguration()
+            };
+
+            return config;
+        }
+
+        private Dictionary<string, object> GetCustomConfiguration()
+        {
+            var customConfiguration = _userSettingsService.CustomConfiguration;
+            try
+            {
+                var config = JsonConvert.DeserializeObject<Dictionary<string, object>>(customConfiguration);
+                return config;
+            }
+            catch (Exception ex)
+            {
+                _logger.Error("Deserializing custom configuration failed.", ex);
+            }
+
+            return null;
+        }
+
+    }
+}

--- a/src/Cody.Core/Infrastructure/IConfigurationService.cs
+++ b/src/Cody.Core/Infrastructure/IConfigurationService.cs
@@ -1,0 +1,10 @@
+using Cody.Core.Agent.Protocol;
+
+namespace Cody.Core.Infrastructure
+{
+    public interface IConfigurationService
+    {
+        ClientInfo GetClientInfo();
+        ExtensionConfiguration GetConfiguration();
+    }
+}

--- a/src/Cody.Core/Settings/IUserSettingsService.cs
+++ b/src/Cody.Core/Settings/IUserSettingsService.cs
@@ -9,6 +9,7 @@ namespace Cody.Core.Settings
         string AccessToken { get; set; }
         string ServerEndpoint { get; set; }
         string CodySettings { get; set; }
+        string CustomConfiguration { get; set; }
         bool AcceptNonTrustedCert { get; set; }
 
 

--- a/src/Cody.Core/Settings/IUserSettingsService.cs
+++ b/src/Cody.Core/Settings/IUserSettingsService.cs
@@ -8,7 +8,6 @@ namespace Cody.Core.Settings
 
         string AccessToken { get; set; }
         string ServerEndpoint { get; set; }
-        string CodySettings { get; set; }
         string CustomConfiguration { get; set; }
         bool AcceptNonTrustedCert { get; set; }
 

--- a/src/Cody.Core/Settings/UserSettingsService.cs
+++ b/src/Cody.Core/Settings/UserSettingsService.cs
@@ -102,6 +102,12 @@ namespace Cody.Core.Settings
             set => Set(nameof(CodySettings), value);
         }
 
+        public string CustomConfiguration
+        {
+            get => GetOrDefault(nameof(CustomConfiguration), string.Empty);
+            set => Set(nameof(CustomConfiguration), value);
+        }
+
         public bool AcceptNonTrustedCert
         {
             get

--- a/src/Cody.Core/Settings/UserSettingsService.cs
+++ b/src/Cody.Core/Settings/UserSettingsService.cs
@@ -95,13 +95,6 @@ namespace Cody.Core.Settings
             }
         }
 
-
-        public string CodySettings
-        {
-            get => GetOrDefault(nameof(CodySettings), string.Empty);
-            set => Set(nameof(CodySettings), value);
-        }
-
         public string CustomConfiguration
         {
             get => GetOrDefault(nameof(CustomConfiguration), string.Empty);

--- a/src/Cody.UI/Controls/Options/GeneralOptionsControl.xaml
+++ b/src/Cody.UI/Controls/Options/GeneralOptionsControl.xaml
@@ -17,80 +17,12 @@
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
                 </Grid.RowDefinitions>
 
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto" />
                     <ColumnDefinition Width="Auto" />
-
                 </Grid.ColumnDefinitions>
-
-
-                <!--Cody Configurations-->
-                <Label 
-                    Grid.Row="1"
-                    Grid.Column="0"
-                    Content="Cody Settings"
-                    />
-
-                <TextBox
-                    Grid.Row="1"
-                    Grid.Column="1"
-                    Width="400"
-                    Height="50"
-                    Text="{Binding Configurations, Mode=TwoWay}"
-                    ToolTip="Your Cody configuration JSON file."
-                    Name="ConfigurationsTextBox"
-                    />
-
-                <!--Custom Configuration-->
-                <StackPanel
-                    Grid.Row="2"
-                    Grid.Column="0"
-                    >
-                    <Label Content="Custom Configuration" />
-                    <Label Content="(requires VS restart)" HorizontalAlignment="Center"
-                           Padding="0"
-                           />
-                </StackPanel>
-
-                <TextBox
-                    Margin="0 2 0 5"
-                    Grid.Row="2"
-                    Grid.Column="1"
-                    Width="400"
-                    Height="100"
-                    Text="{Binding CustomConfiguration, Mode=TwoWay}"
-                    TextWrapping="Wrap"
-                    AcceptsReturn="True"
-                    AcceptsTab="True"
-                    ToolTip="Your Cody configuration JSON file."
-                    Name="CustomConfigurationTextBox"
-                />
-
-                <CheckBox
-                    Name="AcceptNonTrustedCertCheckBox"
-                    Grid.Row="3"
-                    Grid.Column="1"
-                    Margin="0 5 0 0"
-                    IsChecked="{Binding AcceptNonTrustedCert, Mode=TwoWay}"
-                    Content="Accept non-trusted certificates (requires restart)"
-                 />
-
-                <!--Get Help-->
-                <Button 
-                    Margin="0 5 0 0"
-                    Grid.Row="4"
-                    Grid.Column="1"
-                    Height="25"
-                    Width="100"
-                    Content="Get Help"
-                    HorizontalAlignment="Left"
-                    Command="{Binding ActivateBetaCommand}"
-                />
-
-
 
                 <!--Sourcegraph URL-->
                 <Label
@@ -108,6 +40,58 @@
                     Text="{Binding SourcegraphUrl, Mode=TwoWay}"
                     ToolTip="Enter the URL of the Sourcegraph instance. For example, https://sourcegraph.example.com"
                 />
+
+                <!--Custom Cody Configuration-->
+                <StackPanel
+                    Grid.Row="1"
+                    Grid.Column="0"
+                    >
+                    <Label Content="Cody Settings (JSON)" />
+                    <Label Content="(requires restart)" HorizontalAlignment="Center"
+                           Padding="0"
+                           />
+                </StackPanel>
+
+                <TextBox
+                    Margin="0 2 0 5"
+                    Grid.Row="1"
+                    Grid.Column="1"
+                    Width="400"
+                    Height="100"
+                    Text="{Binding CustomConfiguration, Mode=TwoWay}"
+                    TextWrapping="Wrap"
+                    AcceptsReturn="True"
+                    AcceptsTab="True"
+                    ToolTip="Your Cody configuration JSON file."
+                    Name="CustomConfigurationTextBox"
+                />
+
+                <!--Accept non-trusted certificates -->
+                <CheckBox
+                    Name="AcceptNonTrustedCertCheckBox"
+                    Grid.Row="2"
+                    Grid.Column="1"
+                    Margin="0 5 0 0"
+                    IsChecked="{Binding AcceptNonTrustedCert, Mode=TwoWay}"
+                    ToolTip="Your Cody configuration JSON file."
+                    Content="Accept non-trusted certificates (requires restart)"
+                 />
+
+                <!--Get Help-->
+                <Button 
+                    Margin="0 5 0 0"
+                    Grid.Row="3"
+                    Grid.Column="1"
+                    Height="25"
+                    Width="100"
+                    Content="Get Help"
+                    HorizontalAlignment="Left"
+                    Command="{Binding ActivateBetaCommand}"
+                />
+
+
+
+                
             </Grid>
         </GroupBox>
     </Grid>

--- a/src/Cody.UI/Controls/Options/GeneralOptionsControl.xaml
+++ b/src/Cody.UI/Controls/Options/GeneralOptionsControl.xaml
@@ -17,6 +17,7 @@
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
                 </Grid.RowDefinitions>
 
                 <Grid.ColumnDefinitions>
@@ -43,9 +44,34 @@
                     Name="ConfigurationsTextBox"
                     />
 
+                <!--Custom Configuration-->
+                <StackPanel
+                    Grid.Row="2"
+                    Grid.Column="0"
+                    >
+                    <Label Content="Custom Configuration" />
+                    <Label Content="(requires VS restart)" HorizontalAlignment="Center"
+                           Padding="0"
+                           />
+                </StackPanel>
+
+                <TextBox
+                    Margin="0 2 0 5"
+                    Grid.Row="2"
+                    Grid.Column="1"
+                    Width="400"
+                    Height="100"
+                    Text="{Binding CustomConfiguration, Mode=TwoWay}"
+                    TextWrapping="Wrap"
+                    AcceptsReturn="True"
+                    AcceptsTab="True"
+                    ToolTip="Your Cody configuration JSON file."
+                    Name="CustomConfigurationTextBox"
+                />
+
                 <CheckBox
                     Name="AcceptNonTrustedCertCheckBox"
-                    Grid.Row="2"
+                    Grid.Row="3"
                     Grid.Column="1"
                     Margin="0 5 0 0"
                     IsChecked="{Binding AcceptNonTrustedCert, Mode=TwoWay}"
@@ -55,7 +81,7 @@
                 <!--Get Help-->
                 <Button 
                     Margin="0 5 0 0"
-                    Grid.Row="3"
+                    Grid.Row="4"
                     Grid.Column="1"
                     Height="25"
                     Width="100"
@@ -64,7 +90,7 @@
                     Command="{Binding ActivateBetaCommand}"
                 />
 
-                
+
 
                 <!--Sourcegraph URL-->
                 <Label

--- a/src/Cody.UI/Controls/Options/GeneralOptionsControl.xaml
+++ b/src/Cody.UI/Controls/Options/GeneralOptionsControl.xaml
@@ -73,7 +73,6 @@
                     Grid.Column="1"
                     Margin="0 5 0 0"
                     IsChecked="{Binding AcceptNonTrustedCert, Mode=TwoWay}"
-                    ToolTip="Your Cody configuration JSON file."
                     Content="Accept non-trusted certificates (requires restart)"
                  />
 

--- a/src/Cody.UI/Controls/Options/GeneralOptionsControl.xaml.cs
+++ b/src/Cody.UI/Controls/Options/GeneralOptionsControl.xaml.cs
@@ -17,10 +17,7 @@ namespace Cody.UI.Controls.Options
             // TextBox binding doesn't work when Visual Studio closes Options window
             // This is a workaround to get bindings updated. The second solution is to use NotifyPropertyChange for every TextBox in the Xaml, but current solution is a little more "clean" - everything is clearly visible in a one place.
             SourcegraphUrlTextBox.GetBindingExpression(TextBox.TextProperty)?.UpdateSource();
-            ConfigurationsTextBox.GetBindingExpression(TextBox.TextProperty)?.UpdateSource();
             CustomConfigurationTextBox.GetBindingExpression(TextBox.TextProperty)?.UpdateSource();
-
-            AcceptNonTrustedCertCheckBox.GetBindingExpression(CheckBox.IsCheckedProperty)?.UpdateSource();
         }
     }
 }

--- a/src/Cody.UI/Controls/Options/GeneralOptionsControl.xaml.cs
+++ b/src/Cody.UI/Controls/Options/GeneralOptionsControl.xaml.cs
@@ -18,6 +18,8 @@ namespace Cody.UI.Controls.Options
             // This is a workaround to get bindings updated. The second solution is to use NotifyPropertyChange for every TextBox in the Xaml, but current solution is a little more "clean" - everything is clearly visible in a one place.
             SourcegraphUrlTextBox.GetBindingExpression(TextBox.TextProperty)?.UpdateSource();
             ConfigurationsTextBox.GetBindingExpression(TextBox.TextProperty)?.UpdateSource();
+            CustomConfigurationTextBox.GetBindingExpression(TextBox.TextProperty)?.UpdateSource();
+
             AcceptNonTrustedCertCheckBox.GetBindingExpression(CheckBox.IsCheckedProperty)?.UpdateSource();
         }
     }

--- a/src/Cody.UI/ViewModels/GeneralOptionsViewModel.cs
+++ b/src/Cody.UI/ViewModels/GeneralOptionsViewModel.cs
@@ -37,21 +37,6 @@ namespace Cody.UI.ViewModels
             }
         }
 
-        private string _codyConfig;
-
-        public string CodyConfigurations
-        {
-            get => _codyConfig;
-            set
-            {
-                if (SetProperty(ref _codyConfig, value))
-                {
-                    _logger.Debug($"Cody Configurations set:{CodyConfigurations}");
-                }
-
-            }
-        }
-
         private string _customConfiguration;
 
         public string CustomConfiguration
@@ -88,7 +73,7 @@ namespace Cody.UI.ViewModels
             {
                 if (SetProperty(ref _acceptNonTrustedCert, value))
                 {
-                    _logger.Debug($"AcceptNonTrustedCert set:{SourcegraphUrl}");
+                    _logger.Debug($"AcceptNonTrustedCert set:{AcceptNonTrustedCert}");
                 }
             }
         }

--- a/src/Cody.UI/ViewModels/GeneralOptionsViewModel.cs
+++ b/src/Cody.UI/ViewModels/GeneralOptionsViewModel.cs
@@ -52,6 +52,21 @@ namespace Cody.UI.ViewModels
             }
         }
 
+        private string _customConfiguration;
+
+        public string CustomConfiguration
+        {
+            get => _customConfiguration;
+            set
+            {
+                if (SetProperty(ref _customConfiguration, value))
+                {
+                    _logger.Debug($"Custom Configurations set:{CustomConfiguration}");
+                }
+
+            }
+        }
+
         private string _sourcegraphUrl;
         public string SourcegraphUrl
         {

--- a/src/Cody.VisualStudio/CodyPackage.cs
+++ b/src/Cody.VisualStudio/CodyPackage.cs
@@ -85,6 +85,7 @@ namespace Cody.VisualStudio
         public IProgressService ProgressService;
         public IAgentProxy AgentClient;
         public ISecretStorageService SecretStorageService;
+        public IConfigurationService ConfigurationService;
 
         public GeneralOptionsViewModel GeneralOptionsViewModel;
         public MainViewModel MainViewModel;
@@ -136,6 +137,8 @@ namespace Cody.VisualStudio
             SecretStorageService = new SecretStorageService(vsSecretStorage);
             UserSettingsService = new UserSettingsService(new UserSettingsProvider(this), SecretStorageService, Logger);
             UserSettingsService.AuthorizationDetailsChanged += AuthorizationDetailsChanged;
+
+            ConfigurationService = new ConfigurationService(VersionService, VsVersionService, SolutionService, UserSettingsService, Logger);
 
             StatusbarService = new StatusbarService();
             ThemeService = new ThemeService(this, Logger);
@@ -195,7 +198,7 @@ namespace Cody.VisualStudio
             {
                 Logger.Debug($"Changing authorization details ...");
 
-                var config = GetConfiguration();
+                var config = ConfigurationService.GetConfiguration();
                 var status = await AgentService.ConfigurationChange(config);
 
                 UpdateCurrentWorkspaceFolder();
@@ -317,75 +320,6 @@ namespace Cody.VisualStudio
             }
         }
 
-        private ClientInfo GetClientInfo()
-        {
-            var clientInfo = new ClientInfo
-            {
-                Name = "VisualStudio",
-                Version = VersionService.Full,
-                IdeVersion = VsVersionService.Version.ToString(),
-                WorkspaceRootUri = SolutionService.GetSolutionDirectory(),
-                Capabilities = new ClientCapabilities
-                {
-                    Authentication = Capability.Enabled,
-                    Completions = "none",
-                    Edit = Capability.None,
-                    EditWorkspace = Capability.None,
-                    ProgressBars = Capability.Enabled,
-                    CodeLenses = Capability.None,
-                    ShowDocument = Capability.Enabled,
-                    Ignore = Capability.Enabled,
-                    UntitledDocuments = Capability.None,
-                    Webview = "native",
-                    WebviewNativeConfig = new WebviewCapabilities
-                    {
-                        View = WebviewView.Single,
-                        CspSource = "'self' https://cody.vs",
-                        WebviewBundleServingPrefix = "https://cody.vs",
-                    },
-                    WebviewMessages = "string-encoded",
-                    GlobalState = "server-managed",
-                    Secrets = "client-managed",
-                },
-                ExtensionConfiguration = GetConfiguration()
-            };
-
-            return clientInfo;
-        }
-
-        private ExtensionConfiguration GetConfiguration()
-        {
-            var config = new ExtensionConfiguration
-            {
-                AnonymousUserID = UserSettingsService.AnonymousUserID,
-                ServerEndpoint = UserSettingsService.ServerEndpoint,
-                Proxy = null,
-                AccessToken = UserSettingsService.AccessToken,
-                AutocompleteAdvancedProvider = null,
-                Debug = true,
-                VerboseDebug = true,
-                CustomConfiguration = GetCustomConfiguration()
-            };
-
-            return config;
-        }
-
-        private Dictionary<string, object> GetCustomConfiguration()
-        {
-            var customConfiguration = UserSettingsService.CustomConfiguration;
-            try
-            {
-                var config = JsonConvert.DeserializeObject<Dictionary<string, object>>(customConfiguration);
-                return config;
-            }
-            catch (Exception ex)
-            {
-                Logger.Error("Deserializing custom configuration failed.", ex);
-            }
-
-            return null;
-        }
-
         private void InitializeAgent()
         {
             try
@@ -399,7 +333,7 @@ namespace Cody.VisualStudio
                         await TestServerConnection(UserSettingsService.ServerEndpoint);
                         AgentClient.Start();
 
-                        var clientConfig = GetClientInfo();
+                        var clientConfig = ConfigurationService.GetClientInfo();
                         AgentService = await AgentClient.Initialize(clientConfig);
 
                         WebViewsManager.SetAgentService(AgentService);

--- a/src/Cody.VisualStudio/CodyPackage.cs
+++ b/src/Cody.VisualStudio/CodyPackage.cs
@@ -38,6 +38,7 @@ using Task = System.Threading.Tasks.Task;
 using Microsoft.VisualStudio.TaskStatusCenter;
 using SolutionEvents = Microsoft.VisualStudio.Shell.Events.SolutionEvents;
 using System.Net;
+using Newtonsoft.Json;
 
 namespace Cody.VisualStudio
 {
@@ -363,9 +364,26 @@ namespace Cody.VisualStudio
                 AutocompleteAdvancedProvider = null,
                 Debug = true,
                 VerboseDebug = true,
+                CustomConfiguration = GetCustomConfiguration()
             };
 
             return config;
+        }
+
+        private Dictionary<string, object> GetCustomConfiguration()
+        {
+            var customConfiguration = UserSettingsService.CustomConfiguration;
+            try
+            {
+                var config = JsonConvert.DeserializeObject<Dictionary<string, object>>(customConfiguration);
+                return config;
+            }
+            catch (Exception ex)
+            {
+                Logger.Error("Deserializing custom configuration failed.", ex);
+            }
+
+            return null;
         }
 
         private void InitializeAgent()

--- a/src/Cody.VisualStudio/Options/GeneralOptionsPage.cs
+++ b/src/Cody.VisualStudio/Options/GeneralOptionsPage.cs
@@ -59,12 +59,14 @@ namespace Cody.VisualStudio.Options
 
 
             var codyConfig = _settingsService.CodySettings;
+            var customConfiguration = _settingsService.CustomConfiguration;
             var sourcegraphUrl = _settingsService.ServerEndpoint;
             var acceptNonTrustedCert = _settingsService.AcceptNonTrustedCert;
 
             _generalOptionsViewModel.CodyConfigurations = codyConfig;
             _generalOptionsViewModel.SourcegraphUrl = sourcegraphUrl;
             _generalOptionsViewModel.AcceptNonTrustedCert = acceptNonTrustedCert;
+            _generalOptionsViewModel.CustomConfiguration = customConfiguration;
 
             _logger.Debug($"Is canceled:{e.Cancel}");
 
@@ -75,10 +77,12 @@ namespace Cody.VisualStudio.Options
             _logger.Debug($"{args.ApplyBehavior}");
 
             var codyConfig = _generalOptionsViewModel.CodyConfigurations;
+            var customConfiguration = _generalOptionsViewModel.CustomConfiguration;
             var sourcegraphUrl = _generalOptionsViewModel.SourcegraphUrl;
             var acceptNonTrustedCert = _generalOptionsViewModel.AcceptNonTrustedCert;
 
             _settingsService.CodySettings = codyConfig;
+            _settingsService.CustomConfiguration = customConfiguration;
             _settingsService.ServerEndpoint = sourcegraphUrl;
             _settingsService.AcceptNonTrustedCert = acceptNonTrustedCert;
         }

--- a/src/Cody.VisualStudio/Options/GeneralOptionsPage.cs
+++ b/src/Cody.VisualStudio/Options/GeneralOptionsPage.cs
@@ -57,13 +57,10 @@ namespace Cody.VisualStudio.Options
         {
             _logger.Debug($"Settings page activated.");
 
-
-            var codyConfig = _settingsService.CodySettings;
             var customConfiguration = _settingsService.CustomConfiguration;
             var sourcegraphUrl = _settingsService.ServerEndpoint;
             var acceptNonTrustedCert = _settingsService.AcceptNonTrustedCert;
 
-            _generalOptionsViewModel.CodyConfigurations = codyConfig;
             _generalOptionsViewModel.SourcegraphUrl = sourcegraphUrl;
             _generalOptionsViewModel.AcceptNonTrustedCert = acceptNonTrustedCert;
             _generalOptionsViewModel.CustomConfiguration = customConfiguration;
@@ -76,12 +73,10 @@ namespace Cody.VisualStudio.Options
         {
             _logger.Debug($"{args.ApplyBehavior}");
 
-            var codyConfig = _generalOptionsViewModel.CodyConfigurations;
             var customConfiguration = _generalOptionsViewModel.CustomConfiguration;
             var sourcegraphUrl = _generalOptionsViewModel.SourcegraphUrl;
             var acceptNonTrustedCert = _generalOptionsViewModel.AcceptNonTrustedCert;
 
-            _settingsService.CodySettings = codyConfig;
             _settingsService.CustomConfiguration = customConfiguration;
             _settingsService.ServerEndpoint = sourcegraphUrl;
             _settingsService.AcceptNonTrustedCert = acceptNonTrustedCert;
@@ -103,7 +98,7 @@ namespace Cody.VisualStudio.Options
 
         public override void ResetSettings()
         {
-            _settingsService.CodySettings = string.Empty;
+            _settingsService.CustomConfiguration = string.Empty;
             _settingsService.ServerEndpoint = string.Empty;
             _settingsService.AcceptNonTrustedCert = false;
 


### PR DESCRIPTION
CLOSE https://linear.app/sourcegraph/issue/CODY-4103/allows-user-to-use-options-page-for-json-customconfiguration

Example custom configuration for Tools->Cody->Cody Settings:

```
{
  'cody.autocomplete.enabled': false,
  'cody.experimental.urlContext': true
}
```