### PR TITLE
Updated CODY_VS_DEV_PORT variable scope to "User"

### DIFF
--- a/src/Cody.VisualStudio/CodyPackage.cs
+++ b/src/Cody.VisualStudio/CodyPackage.cs
@@ -274,7 +274,7 @@ namespace Cody.VisualStudio
             {
                 var agentDir = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "Agent");
 
-                var devPort = Environment.GetEnvironmentVariable("CODY_VS_DEV_PORT");
+                var devPort = Environment.GetEnvironmentVariable("CODY_VS_DEV_PORT", EnvironmentVariableTarget.User);
                 var portNumber = int.TryParse(devPort, out int port) ? port : 3113;
 
                 if (devPort != null)


### PR DESCRIPTION
Improved dev workflow when switching to local Cody agent during debugging or by running VS Experimental without debugger attached. With this PR, Visual Studio doesn't need to be restarted every time when CODY_VS_DEV_PORT is added/changed (enabled/disabled).

## Before

Changing (enabling/disabling) "CODY_VS_DEV_PORT" always requires VS restart, because `GetEnvironmentVariable()` is using "Process" scope.

When using "Process" scope, VS loads all environment variables only once, at startup. Later, during run-time and also debugging, when VS child process is created, every call to `Environment.GetEnvironmentVariable("CODY_VS_DEV_PORT")` gets OLD state of variable copied from main VS process that started child VS process. For this reason, VS needs to be manually restarted every time when CODY_VS_DEV_PORT is changed (added/removed).

## Now

When debugging VS Exp instance, or starting without debugger attached, call to `GetEnvironmentVariable("CODY_VS_DEV_PORT", EnvironmentVariableTarget.User)` always loads the latest variable state dynamically from environment variables:

![image](https://github.com/user-attachments/assets/27c2ce0d-99ec-4267-b003-61a49e6f3fc3)

