### PR TITLE
Release 0.4.0

### DIFF
--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -1,4 +1,4 @@
-name: Release Preview
+name: GitHub Release
 
 on:
   push:
@@ -40,7 +40,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ github.ref }}
-          release_name: Release Preview ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
           draft: false
           prerelease: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## Security
 
+## [0.1.0]
+
+### Added
+
+- Experimental release of [Cody for Visual Studio](https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-vs) 🎉
+
 ## [0.0.3]
 
 ### Added
 
 - "Cody Settings" in user options. [pull/118](https://github.com/sourcegraph/cody-vs/pull/118)
-
 
 ## [0.0.2]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## Security
 
-## [0.1.0]
+## [0.0.4]
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Cody for Visual Studio
 
-🚧 [Cody for Visual Studio](https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-vs) is currently in private preview.
-
-**It is intended for testing purposes only and may not be suitable for production use.**
+Install [Cody for Visual Studio (Experimental)](https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-vs).
 
 ## AI that uses your codebase as context
 
@@ -24,7 +22,7 @@ For example, you can ask Cody:
 ## Choose Your LLM
 
 Cody offers a variety of large language models (LLMs) to power your chat experience.
-Cody Pro users can select the LLM they want to use for chat and experiment to choose the best model for the job. Choose from Claude 3.5 Sonnet,Claude 3 Opus, Claude 3 Sonnet, Claude 3 Haiku, GPT-4o, GPT-4 Turbo, GPT-3.5 Turbo, Google Gemini 1.5 Pro, Gemini 1.5 Flash, and Mixtral, while Cody Free users have access to the latest base models from Anthropic, OpenAI, Google, and Mixtral.
+Cody Pro users can select the LLM they want to use for chat and experiment to choose the best model for the job. Choose from Claude 3.5 Sonnet, Claude 3 Opus, Claude 3 Sonnet, Claude 3 Haiku, GPT-4o, GPT-4 Turbo, GPT-3.5 Turbo, Google Gemini 1.5 Pro, Gemini 1.5 Flash, and Mixtral, while Cody Free users have access to the latest base models from Anthropic, OpenAI, Google, and Mixtral.
 Local models are also available through Ollama to both Cody Free and Cody Pro users. Simply download the model and run it in Ollama to use it in Cody chat.
 
 Administrators for Sourcegraph Enterprise instances can choose between Claude and GPT models to set for their teams as well.
@@ -36,12 +34,6 @@ This extension works for all Cody plans, including Cody Free, Cody Pro, and Cody
 You can find detailed information about Cody's available plans [on our website](https://sourcegraph.com/pricing?utm_source=marketplace.visualstudio.com&utm_medium=referral).
 
 ### Feedback
-
-As the extension is currently in preview, here are what to expect:
-
-- You might encounter bugs or unexpected behavior
-- Features and user interface are subject to change
-- The extension has limited functionality compared to the VS Code extension
 
 We appreciate your feedback as we work to improve Cody for Visual Studio. Please report any issues or suggestions through our official channels:
 

--- a/docs/dev/Release.md
+++ b/docs/dev/Release.md
@@ -11,10 +11,10 @@ Follow these steps to publish a new release to the [Visual Studio Marketplace](h
 
 1. **Coordinate with Marketing**: Contact the Marketing team in the Cody Slack channel approximately 2 days before the release to ensure a blog post is prepared.
 2. **Update Extension Package Version**: Increment the version in [source.extension.vsixmanifest](../../src/Cody.VisualStudio/source.extension.vsixmanifest) and [CHANGELOG.md](../../CHANGELOG.md).
-3. **Commit the Version Changes**: Commit the version increment with a message with `git commit -m VS Code: Release vX.Y.Z`
+3. **Commit the Version Changes**: Commit the version increment with a message with `git commit -m Release vX.Y.Z`
 4. **Create Pull Request**: Open a PR with the updated version.
 5. **Tag the Release**: After the PR is merged (stable release only), create a git tag: `git tag vX.Y.Z`
-6. **Push the Tag**: Push the tag to the remote repository to trigger the [Release Preview workflow](https://github.com/sourcegraph/cody-vs/actions/workflows/release-preview.yml): `git push --tags`
+6. **Push the Tag**: Push the tag to the remote repository to trigger the [Release workflow](https://github.com/sourcegraph/cody-vs/actions/workflows/release-preview.yml): `git push --tags`
 7. **Monitor Publication**: Once the workflow run is complete:
    - The new version of the extension will be published to the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-vs).
    - A release will be created on GitHub with the release notes.

--- a/docs/limitation.md
+++ b/docs/limitation.md
@@ -1,6 +1,6 @@
 # Known Limitations
 
-The extension is currently in preview:
+The extension is currently in experimental mode and has several limitations. The following list outlines the known limitations in the current version of the extension:
 
 - You might encounter bugs or unexpected behavior
 - Features and user interface are subject to change

--- a/docs/qa/Testing.md
+++ b/docs/qa/Testing.md
@@ -1,6 +1,6 @@
 # Testing Cody for Visual Studio
 
-**NOTE:** Cody for Visual Studio is currently in Preview and may have limited functionality compared to the VS Code version.
+**NOTE:** Cody for Visual Studio is currently experimental and may have limited functionality compared to the VS Code version.
 
 This test plan outlines the comprehensive testing procedures for Cody in Visual Studio.
 
@@ -14,24 +14,24 @@ Before beginning the test plan, ensure you have:
   - Supported versions: Community, Professional, and Enterprise
 - [ ] A codebase with a Visual Studio solution file
   - To create a new solution project, follow the instructions in the [Create a solution documentation](https://learn.microsoft.com/en-us/visualstudio/get-started/tutorial-projects-solutions?view=vs-2022#create-a-solution)
-- [ ] Preview version of [Cody for Visual Studio extension](https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-vs) installed
+- [ ] Latest version of [Cody for Visual Studio extension](https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-vs) installed
 
 **IMPORTANT:** Cody requires an open solution in Visual Studio to provide context-aware responses. Ensure you have a solution project opened before testing Cody features.
 
-## Installing Cody for Visual Studio (Preview)
+## Installing Cody for Visual Studio (Experimental)
 
-To install the preview version of Cody for Visual Studio:
+To install Cody for Visual Studio from GitHub Release Page:
 
 1. Visit the [GitHub Releases Page](https://github.com/sourcegraph/cody-vs/releases)
 2. Download `Cody.VisualStudio.vsix` from the latest release's **Assets** section
 3. Close `Visual Studio`
 4. Double-click the downloaded file to install the extension
 
-As this is a preview version, you may encounter bugs or limitations. Please report any issues on the [GitHub repository](https://github.com/sourcegraph/cody-vs/issues).
+Please report any issues on the [GitHub repository](https://github.com/sourcegraph/cody-vs/issues).
 
 ### Public Release Version
 
-Once generally available, the extension will be on the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-vs).
+The extension is also available on the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-vs).
 
 1. Open Visual Studio.
 2. Go to `Extensions` > `Manage Extensions`.

--- a/src/Cody.VisualStudio/source.extension.vsixmanifest
+++ b/src/Cody.VisualStudio/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="Cody.VisualStudio" Version="0.0.3" Language="en-US" Publisher="sourcegraph" />
+        <Identity Id="Cody.VisualStudio" Version="0.1.0" Language="en-US" Publisher="sourcegraph" />
         <DisplayName>Cody for Visual Studio - AI Coding Assistant</DisplayName>
         <Description xml:space="preserve">AI coding assistant that uses search and codebase context to help you write code faster!</Description>
         <MoreInfo>https://sourcegraph.com/cody</MoreInfo>

--- a/src/Cody.VisualStudio/source.extension.vsixmanifest
+++ b/src/Cody.VisualStudio/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="Cody.VisualStudio" Version="0.1.0" Language="en-US" Publisher="sourcegraph" />
+        <Identity Id="Cody.VisualStudio" Version="0.0.4" Language="en-US" Publisher="sourcegraph" />
         <DisplayName>Cody for Visual Studio - AI Coding Assistant</DisplayName>
         <Description xml:space="preserve">AI coding assistant that uses search and codebase context to help you write code faster!</Description>
         <MoreInfo>https://sourcegraph.com/cody</MoreInfo>

--- a/src/build.cake
+++ b/src/build.cake
@@ -46,7 +46,7 @@ var nodeBinaryUrl = "https://github.com/sourcegraph/node-binaries/raw/main/v20.1
 var nodeArmBinaryUrl = "https://github.com/sourcegraph/node-binaries/raw/main/v20.12.2/node-win-arm64.exe";
 
 // The latest tag of the stable release from the cody repository https://github.com/sourcegraph/cody/tags
-var codyStableReleaseTag = "vscode-v1.38.3";
+var codyStableReleaseTag = "vscode-v1.40.0";
 var codyBranch = Argument("cody-branch", codyStableReleaseTag);
 
 var marketplaceToken = EnvironmentVariable("CODY_VS_MARKETPLACE_RELEASE_TOKEN");

--- a/src/build.cake
+++ b/src/build.cake
@@ -46,7 +46,7 @@ var nodeBinaryUrl = "https://github.com/sourcegraph/node-binaries/raw/main/v20.1
 var nodeArmBinaryUrl = "https://github.com/sourcegraph/node-binaries/raw/main/v20.12.2/node-win-arm64.exe";
 
 // The latest tag of the stable release from the cody repository https://github.com/sourcegraph/cody/tags
-var codyStableReleaseTag = "vscode-v1.38.1";
+var codyStableReleaseTag = "vscode-v1.38.3";
 var codyBranch = Argument("cody-branch", codyStableReleaseTag);
 
 var marketplaceToken = EnvironmentVariable("CODY_VS_MARKETPLACE_RELEASE_TOKEN");


### PR DESCRIPTION
The extension is now in experimental mode. 

This PR includes the following changes:

- Update extension version to 0.1.0
- Update README.md to reflect the extension is now experimental
- Update documentation to reflect the extension is experimental
- Update release workflow to use the correct name
- Update the Cody stable release tag to the next stable version `vscode-v1.40.0`

Do not 

## TODO for @kalanchan  
- [x] update the extension version number as commented below
- [x] update cody main repo commit as commented below
- [ ] Start the release process once `vscode-v1.40.0` is released, following the Release.md docs 
- [ ] once the package has been released to the GitHub Release page, download the vsix file from the Release page and upload it to the marketplace (see instruction below)
- [ ] Make the extension public

To upload the vsix package to the Marketplace:
1. Sign in with an admin account ( ask the visual studio team or security team to add you to the sourcegraph org)
2. Go to the [cody-vs manage page](https://marketplace.visualstudio.com/manage/publishers/sourcegraph/extensions/cody-vs/edit) and click on the pencil icon to upload the vsix package you downloaded from the GitHub Release page:
<img width="1136" alt="image" src="https://github.com/user-attachments/assets/0c45298e-e453-4289-aa8a-984f415466b1">
3. Update the Overview field with the updated README.md to remove mentions of "Preview"
4. Submit the changes
5. To change it from preview to public, click on the Make Public button in the [extensions manage page](https://marketplace.visualstudio.com/manage/publishers/sourcegraph?src=sourcegraph.cody-vs):
<img width="957" alt="image" src="https://github.com/user-attachments/assets/9c38e2f5-66b1-41b9-8084-6a51bf08c7c4">
