### PR TITLE
Support for automatically taking screenshots at the end of each UI test (passed or failed).

### DIFF
--- a/.github/workflows/cake-build.yml
+++ b/.github/workflows/cake-build.yml
@@ -73,7 +73,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: Failed Tests Screenshots
-          path: src\Cody.VisualStudio.Tests\bin\Debug\Screenshots\**\*.png
+          path: src\Cody.VisualStudio.Tests\bin\Debug\Screenshots\*.png
           retention-days: 20
 
       - name: Publish Test Results

--- a/.github/workflows/cake-build.yml
+++ b/.github/workflows/cake-build.yml
@@ -74,9 +74,8 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: Failed Tests Screenshots
-          path: .\Cody.VisualStudio.Tests\bin\Debug\Screenshots
+          path: src/Cody.VisualStudio.Tests/bin/Debug/Screenshots
           retention-days: 20
-        run: cd src
 
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action/windows@v2

--- a/.github/workflows/cake-build.yml
+++ b/.github/workflows/cake-build.yml
@@ -72,13 +72,12 @@ jobs:
         run: |
           cd src
           dotnet test .\Cody.Core.Tests\bin\Debug\Cody.Core.Tests.dll .\Cody.VisualStudio.Tests\bin\Debug\Cody.VisualStudio.Tests.dll -v detailed -l:trx
-          dir .\Cody.VisualStudio.Tests\bin\Debug\Screenshots
 
-      - name: Upload screenshots for failed tests
+      - name: Upload screenshots for UI tests
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: Failed Tests Screenshots
+          name: UI Tests Screenshots
           path: src/Cody.VisualStudio.Tests/bin/Debug/Screenshots
           retention-days: 20
 

--- a/.github/workflows/cake-build.yml
+++ b/.github/workflows/cake-build.yml
@@ -31,9 +31,6 @@ jobs:
       - name: Change Screen Resolution
         shell: pwsh
         run: |
-           [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-           Install-PackageProvider NuGet -Force
-           Install-Module -Name DisplaySettings -Force
            Set-DisplayResolution -Width 1920 -Height 1080 -Force
 
       - name: ⚙️ Prepare Visual Studio

--- a/.github/workflows/cake-build.yml
+++ b/.github/workflows/cake-build.yml
@@ -69,14 +69,14 @@ jobs:
           cd src
           dotnet test .\Cody.Core.Tests\bin\Debug\Cody.Core.Tests.dll .\Cody.VisualStudio.Tests\bin\Debug\Cody.VisualStudio.Tests.dll -v detailed -l:trx
           dir .\Cody.VisualStudio.Tests\bin\Debug\Screenshots
-          echo "This is a file to upload" > .\Cody.VisualStudio.Tests\bin\Debug\Screenshots\file.txt
 
       - name: Upload screenshots for failed tests
         uses: actions/upload-artifact@v4
         with:
           name: Failed Tests Screenshots
-          path: .\src\Cody.VisualStudio.Tests\bin\Debug\Screenshots
+          path: .\Cody.VisualStudio.Tests\bin\Debug\Screenshots
           retention-days: 20
+        run: cd src
 
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action/windows@v2

--- a/.github/workflows/cake-build.yml
+++ b/.github/workflows/cake-build.yml
@@ -28,6 +28,13 @@ jobs:
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.3
 
+      - name: Change Screen Resolution
+        shell: pwsh
+        run: |
+           Install-PackageProvider -Name NuGet -Force
+           Install-Module -Name DisplaySettings -Force
+           Set-DisplayResolution -Width 1920 -Height 1080 -Force
+
       - name: ⚙️ Prepare Visual Studio
         run: '&"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\devenv.exe" /RootSuffix Exp /ResetSettings General.vssettings'
 

--- a/.github/workflows/cake-build.yml
+++ b/.github/workflows/cake-build.yml
@@ -30,8 +30,7 @@ jobs:
 
       - name: Change Screen Resolution
         shell: pwsh
-        run: |
-           Set-DisplayResolution -Width 1920 -Height 1080 -Force
+        run: Set-DisplayResolution -Width 1920 -Height 1080 -Force
 
       - name: ⚙️ Prepare Visual Studio
         run: '&"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\devenv.exe" /RootSuffix Exp /ResetSettings General.vssettings'

--- a/.github/workflows/cake-build.yml
+++ b/.github/workflows/cake-build.yml
@@ -31,6 +31,7 @@ jobs:
       - name: Change Screen Resolution
         shell: pwsh
         run: |
+           [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
            Install-PackageProvider NuGet -Force
            Install-Module -Name DisplaySettings -Force
            Set-DisplayResolution -Width 1920 -Height 1080 -Force

--- a/.github/workflows/cake-build.yml
+++ b/.github/workflows/cake-build.yml
@@ -2,7 +2,7 @@
 
 on:
   push:
-    branches: [piotr/uitests-ci-improvements]
+    branches: [main]
   pull_request:
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/cake-build.yml
+++ b/.github/workflows/cake-build.yml
@@ -68,12 +68,14 @@ jobs:
         run: |
           cd src
           dotnet test .\Cody.Core.Tests\bin\Debug\Cody.Core.Tests.dll .\Cody.VisualStudio.Tests\bin\Debug\Cody.VisualStudio.Tests.dll -v detailed -l:trx
+          mkdir .\Cody.VisualStudio.Tests\bin\Debug\Screenshots
+          echo "This is a file to upload" > .\Cody.VisualStudio.Tests\bin\Debug\Screenshots\file.txt
 
       - name: Upload screenshots for failed tests
         uses: actions/upload-artifact@v4
         with:
           name: Failed Tests Screenshots
-          path: src\Cody.VisualStudio.Tests\bin\Debug\Screenshots\
+          path: .\src\Cody.VisualStudio.Tests\bin\Debug\Screenshots
           retention-days: 20
 
       - name: Publish Test Results

--- a/.github/workflows/cake-build.yml
+++ b/.github/workflows/cake-build.yml
@@ -68,7 +68,7 @@ jobs:
         run: |
           cd src
           dotnet test .\Cody.Core.Tests\bin\Debug\Cody.Core.Tests.dll .\Cody.VisualStudio.Tests\bin\Debug\Cody.VisualStudio.Tests.dll -v detailed -l:trx
-          mkdir .\Cody.VisualStudio.Tests\bin\Debug\Screenshots
+          dir .\Cody.VisualStudio.Tests\bin\Debug\Screenshots
           echo "This is a file to upload" > .\Cody.VisualStudio.Tests\bin\Debug\Screenshots\file.txt
 
       - name: Upload screenshots for failed tests

--- a/.github/workflows/cake-build.yml
+++ b/.github/workflows/cake-build.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Change Screen Resolution
         shell: pwsh
         run: |
-           Install-PackageProvider -Name NuGet -Force
+           Install-PackageProvider NuGet -Force
            Install-Module -Name DisplaySettings -Force
            Set-DisplayResolution -Width 1920 -Height 1080 -Force
 

--- a/.github/workflows/cake-build.yml
+++ b/.github/workflows/cake-build.yml
@@ -70,10 +70,10 @@ jobs:
           dotnet test .\Cody.Core.Tests\bin\Debug\Cody.Core.Tests.dll .\Cody.VisualStudio.Tests\bin\Debug\Cody.VisualStudio.Tests.dll -v detailed -l:trx
 
       - name: Upload screenshots for failed tests
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Failed Tests Screenshots
-          path: src\Cody.VisualStudio.Tests\bin\Debug\Screenshots\*.png
+          path: src\Cody.VisualStudio.Tests\bin\Debug\Screenshots\
           retention-days: 20
 
       - name: Publish Test Results

--- a/.github/workflows/cake-build.yml
+++ b/.github/workflows/cake-build.yml
@@ -69,6 +69,13 @@ jobs:
           cd src
           dotnet test .\Cody.Core.Tests\bin\Debug\Cody.Core.Tests.dll .\Cody.VisualStudio.Tests\bin\Debug\Cody.VisualStudio.Tests.dll -v detailed -l:trx
 
+      - name: Upload screenshots for failed tests
+        uses: actions/upload-artifact@v3
+        with:
+          name: Failed Tests Screenshots
+          path: src\Cody.VisualStudio.Tests\bin\Debug\Screenshots\**\*.png
+          retention-days: 20
+
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action/windows@v2
         if: always()

--- a/.github/workflows/cake-build.yml
+++ b/.github/workflows/cake-build.yml
@@ -2,7 +2,7 @@
 
 on:
   push:
-    branches: [main]
+    branches: [piotr/uitests-ci-improvements]
   pull_request:
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/cake-build.yml
+++ b/.github/workflows/cake-build.yml
@@ -72,6 +72,7 @@ jobs:
 
       - name: Upload screenshots for failed tests
         uses: actions/upload-artifact@v4
+        if: always()
         with:
           name: Failed Tests Screenshots
           path: src/Cody.VisualStudio.Tests/bin/Debug/Screenshots

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -20,6 +20,10 @@ jobs:
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.3
 
+      - name: Change Screen Resolution
+        shell: pwsh
+        run: Set-DisplayResolution -Width 1920 -Height 1080 -Force
+
       - name: ⚙️ Prepare Visual Studio
         run: '&"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\devenv.exe" /RootSuffix Exp /ResetSettings General.vssettings'
 
@@ -52,6 +56,14 @@ jobs:
         run: |
           cd src
           dotnet test .\Cody.VisualStudio.Tests\bin\Debug\Cody.VisualStudio.Tests.dll -v detailed -l:trx
+
+      - name: Upload screenshots for UI tests
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: UI Tests Screenshots
+          path: src/Cody.VisualStudio.Tests/bin/Debug/Screenshots
+          retention-days: 5
 
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action/windows@v2

--- a/src/Cody.Core.Tests/CustomConfigurationTests.cs
+++ b/src/Cody.Core.Tests/CustomConfigurationTests.cs
@@ -64,7 +64,7 @@ namespace Cody.Core.Tests
             // given
             var key1 = "cody.autocomplete.enabled";
             var key2 = "cody.customHeaders";
-            var key3 = "cody.customHeaders";
+            var key3 = "cody.excludeFiles";
             var configurationJson = $@"{{
                         	""{key1}"": true,
 	                        ""{key2}"": {{

--- a/src/Cody.VisualStudio.Tests/ChatLoggedBasicTests.cs
+++ b/src/Cody.VisualStudio.Tests/ChatLoggedBasicTests.cs
@@ -60,7 +60,7 @@ namespace Cody.VisualStudio.Tests
             Assert.True(isOpen);
         }
 
-        [VsFact(Version = VsVersion.VS2022)]
+        //[VsFact(Version = VsVersion.VS2022)]
         public async Task Entered_Prompt_Show_Up_In_Today_History()
         {
             var num = new Random().Next();

--- a/src/Cody.VisualStudio.Tests/ChatLoggedBasicTests.cs
+++ b/src/Cody.VisualStudio.Tests/ChatLoggedBasicTests.cs
@@ -82,8 +82,7 @@ namespace Cody.VisualStudio.Tests
         public void Dispose()
         {
             var testName = GetTestName();
-            TakeScreenShot(testName);
-
+            TakeScreenshot(testName);
         }
     }
 }

--- a/src/Cody.VisualStudio.Tests/ChatLoggedBasicTests.cs
+++ b/src/Cody.VisualStudio.Tests/ChatLoggedBasicTests.cs
@@ -60,7 +60,7 @@ namespace Cody.VisualStudio.Tests
             Assert.True(isOpen);
         }
 
-        //[VsFact(Version = VsVersion.VS2022)]
+        [VsFact(Version = VsVersion.VS2022)]
         public async Task Entered_Prompt_Show_Up_In_Today_History()
         {
             var num = new Random().Next();

--- a/src/Cody.VisualStudio.Tests/ChatLoggedBasicTests.cs
+++ b/src/Cody.VisualStudio.Tests/ChatLoggedBasicTests.cs
@@ -1,34 +1,15 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
-using EnvDTE;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace Cody.VisualStudio.Tests
 {
-    public class ChatLoggedBasicTests : PlaywrightTestsBase
+    public class ChatLoggedBasicTests : PlaywrightTestsBase, IDisposable
     {
         public ChatLoggedBasicTests(ITestOutputHelper output) : base(output)
         {
-        }
-
-        [VsFact(Version = VsVersion.VS2022)]
-        public void Test()
-        {
-            throw new Exception("test");
-        }
-
-        [VsFact(Version = VsVersion.VS2022)]
-        public async void TestAsyncVoid()
-        {
-            throw new Exception("async test1");
-        }
-
-        [VsFact(Version = VsVersion.VS2022)]
-        public async Task TestAsync()
-        {
-            throw new Exception("async test1");
         }
 
         [VsFact(Version = VsVersion.VS2022)]
@@ -95,6 +76,13 @@ namespace Cody.VisualStudio.Tests
             var chatHistoryEntries = await GetTodayChatHistory();
 
             Assert.Contains(chatHistoryEntries, x => x.Contains(prompt));
+
+        }
+
+        public void Dispose()
+        {
+            var testName = GetTestName();
+            TakeScreenShot(testName);
 
         }
     }

--- a/src/Cody.VisualStudio.Tests/ChatLoggedBasicTests.cs
+++ b/src/Cody.VisualStudio.Tests/ChatLoggedBasicTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using EnvDTE;
@@ -12,6 +11,24 @@ namespace Cody.VisualStudio.Tests
     {
         public ChatLoggedBasicTests(ITestOutputHelper output) : base(output)
         {
+        }
+
+        [VsFact(Version = VsVersion.VS2022)]
+        public void Test()
+        {
+            throw new Exception("test");
+        }
+
+        [VsFact(Version = VsVersion.VS2022)]
+        public async void TestAsyncVoid()
+        {
+            throw new Exception("async test1");
+        }
+
+        [VsFact(Version = VsVersion.VS2022)]
+        public async Task TestAsync()
+        {
+            throw new Exception("async test1");
         }
 
         [VsFact(Version = VsVersion.VS2022)]

--- a/src/Cody.VisualStudio.Tests/ChatNotLoggedStateTests.cs
+++ b/src/Cody.VisualStudio.Tests/ChatNotLoggedStateTests.cs
@@ -8,7 +8,7 @@ using Xunit.Abstractions;
 
 namespace Cody.VisualStudio.Tests
 {
-    public class ChatNotLoggedStateTests : PlaywrightTestsBase
+    public class ChatNotLoggedStateTests : PlaywrightTestsBase, IDisposable
     {
         public ChatNotLoggedStateTests(ITestOutputHelper output) : base(output)
         {
@@ -42,6 +42,12 @@ namespace Cody.VisualStudio.Tests
 
             // then
             Assert.Equal(text, textContents.First());
+        }
+
+        public void Dispose()
+        {
+            var testName = GetTestName();
+            TakeScreenshot(testName);
         }
     }
 }

--- a/src/Cody.VisualStudio.Tests/Cody.VisualStudio.Tests.csproj
+++ b/src/Cody.VisualStudio.Tests/Cody.VisualStudio.Tests.csproj
@@ -37,6 +37,7 @@
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Drawing" />
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Xml.Linq" />
@@ -52,6 +53,7 @@
     </Compile>
     <Compile Include="ChatNotLoggedStateTests.cs" />
     <Compile Include="ChatLoggedBasicTests.cs" />
+    <Compile Include="ScreenshotUtil.cs" />
     <Compile Include="PlaywrightTestsBase.cs" />
     <Compile Include="PlaywrightInitializationTests.cs" />
     <Compile Include="CodyPackageTests.cs" />

--- a/src/Cody.VisualStudio.Tests/PlaywrightTestsBase.cs
+++ b/src/Cody.VisualStudio.Tests/PlaywrightTestsBase.cs
@@ -162,8 +162,14 @@ namespace Cody.VisualStudio.Tests
         {
             var tagsList = new List<ContextTag>();
 
+            WriteLog("Searching for Chat ...");
             var chatBox = await Page.QuerySelectorAsync("[aria-label='Chat message']");
-            if (chatBox == null) throw new Exception("ChatBox is null. Probably not authenticated.");
+            if (chatBox == null)
+            {
+                WriteLog("Chat NOT found.");
+                throw new Exception("ChatBox is null. Probably not authenticated.");
+            }
+            WriteLog("Chat found.");
 
             var list = await chatBox.QuerySelectorAllAsync("span[data-lexical-decorator='true']");
             foreach (var item in list)

--- a/src/Cody.VisualStudio.Tests/PlaywrightTestsBase.cs
+++ b/src/Cody.VisualStudio.Tests/PlaywrightTestsBase.cs
@@ -127,7 +127,11 @@ namespace Cody.VisualStudio.Tests
 
         protected async Task ShowChatTab() => await Page.GetByTestId("tab-chat").ClickAsync();
 
-        protected async Task ShowHistoryTab() => await Page.GetByTestId("tab-history").ClickAsync();
+        protected async Task ShowHistoryTab()
+        {
+            await Page.GetByTestId("tab-history").ClickAsync();
+            await Task.Delay(500);
+        }
 
         protected async Task ShowPromptsTab() => await Page.GetByTestId("tab-prompts").ClickAsync();
 

--- a/src/Cody.VisualStudio.Tests/Properties/AssemblyInfo.cs
+++ b/src/Cody.VisualStudio.Tests/Properties/AssemblyInfo.cs
@@ -33,3 +33,4 @@ using Xunit;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: TestFramework("Xunit.VsTestFramework", "VsixTesting.Xunit")]
 [assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly, DisableTestParallelization = true, MaxParallelThreads = 1)]
+[assembly:VsTestSettings(TakeScreenshotOnFailure = true)]

--- a/src/Cody.VisualStudio.Tests/Properties/AssemblyInfo.cs
+++ b/src/Cody.VisualStudio.Tests/Properties/AssemblyInfo.cs
@@ -33,4 +33,4 @@ using Xunit;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: TestFramework("Xunit.VsTestFramework", "VsixTesting.Xunit")]
 [assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly, DisableTestParallelization = true, MaxParallelThreads = 1)]
-[assembly:VsTestSettings(TakeScreenshotOnFailure = true)]
+[assembly: VsTestSettings(TakeScreenshotOnFailure = true)]

--- a/src/Cody.VisualStudio.Tests/ScreenshotUtil.cs
+++ b/src/Cody.VisualStudio.Tests/ScreenshotUtil.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Drawing;
+using System.Drawing.Imaging;
+
+namespace Cody.VisualStudio.Tests
+{
+    public class ScreenshotUtil
+    {
+        public static void CaptureWindow(IntPtr hwnd, string path)
+        {
+            var rect = default(RECT);
+            GetWindowRect(hwnd, ref rect);
+            CaptureScreenArea(
+                path,
+                left: rect.Left,
+                top: rect.Top,
+                width: rect.Right - rect.Left,
+                height: rect.Bottom - rect.Top);
+        }
+
+        public static void CaptureScreenArea(string path, int left, int top, int width, int height)
+        {
+            using (var bitmap = new Bitmap(width, height))
+            using (var image = Graphics.FromImage(bitmap))
+            {
+                image.CopyFromScreen(
+                    sourceX: left,
+                    sourceY: top,
+                    blockRegionSize: new Size(width, height),
+                    copyPixelOperation: CopyPixelOperation.SourceCopy,
+                    destinationX: 0,
+                    destinationY: 0);
+
+                bitmap.Save(path, ImageFormat.Png);
+            }
+        }
+
+        [DllImport("user32.dll")]
+        private static extern bool GetWindowRect(IntPtr hWnd, ref RECT rect);
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct RECT
+        {
+            public int Left;
+            public int Top;
+            public int Right;
+            public int Bottom;
+        }
+    }
+
+}

--- a/src/Cody.VisualStudio.Tests/TestsBase.cs
+++ b/src/Cody.VisualStudio.Tests/TestsBase.cs
@@ -60,9 +60,11 @@ namespace Cody.VisualStudio.Tests
             var directoryPath = Path.GetFullPath(Path.Combine(directory));
             var path = Path.Combine(directoryPath, $"{date} {safeName}.png");
 
+            WriteLog($"Saving screenshots to:{directoryPath}");
             Directory.CreateDirectory(directoryPath);
 
             ScreenshotUtil.CaptureWindow(Process.GetCurrentProcess().MainWindowHandle, path);
+            WriteLog($"Screenshot saved to:{path}");
         }
 
         private IVsUIShell _uiShell;

--- a/src/Cody.VisualStudio.Tests/TestsBase.cs
+++ b/src/Cody.VisualStudio.Tests/TestsBase.cs
@@ -46,9 +46,12 @@ namespace Cody.VisualStudio.Tests
 
         protected async Task OpenSolution(string path)
         {
+
+            _logger.WriteLine("Opening solution '{path}' ...");
             Dte.Solution.Open(path);
 
             await Task.Delay(TimeSpan.FromSeconds(5));
+            _logger.WriteLine("Delay after solution open stopped.");
         }
 
         protected void CloseSolution() => Dte.Solution.Close();

--- a/src/Cody.VisualStudio.Tests/TestsBase.cs
+++ b/src/Cody.VisualStudio.Tests/TestsBase.cs
@@ -57,7 +57,7 @@ namespace Cody.VisualStudio.Tests
             var date = DateTime.Now.ToString("yyyy-MM-dd hh.mm.ss");
 
             var directory = "Screenshots";
-            var directoryPath = Path.GetFullPath(Path.Combine(directory));
+            var directoryPath = Path.GetFullPath(Path.Combine(Assembly.GetExecutingAssembly().Location, directory));
             var path = Path.Combine(directoryPath, $"{date} {safeName}.png");
 
             WriteLog($"Saving screenshots to:{directoryPath}");

--- a/src/Cody.VisualStudio.Tests/TestsBase.cs
+++ b/src/Cody.VisualStudio.Tests/TestsBase.cs
@@ -51,7 +51,7 @@ namespace Cody.VisualStudio.Tests
             return testName;
         }
 
-        protected void TakeScreenShot(string name)
+        protected void TakeScreenshot(string name)
         {
             var safeName = string.Join("_", name.Split(Path.GetInvalidFileNameChars()));
             var date = DateTime.Now.ToString("yyyy-MM-dd hh.mm.ss");

--- a/src/Cody.VisualStudio.Tests/TestsBase.cs
+++ b/src/Cody.VisualStudio.Tests/TestsBase.cs
@@ -57,7 +57,7 @@ namespace Cody.VisualStudio.Tests
             var date = DateTime.Now.ToString("yyyy-MM-dd hh.mm.ss");
 
             var directory = "Screenshots";
-            var directoryPath = Path.GetFullPath(Path.Combine(Assembly.GetExecutingAssembly().Location, directory));
+            var directoryPath = Path.GetFullPath(Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), directory));
             var path = Path.Combine(directoryPath, $"{date} {safeName}.png");
 
             WriteLog($"Saving screenshots to:{directoryPath}");

--- a/src/Cody.VisualStudio.Tests/TestsBase.cs
+++ b/src/Cody.VisualStudio.Tests/TestsBase.cs
@@ -47,11 +47,11 @@ namespace Cody.VisualStudio.Tests
         protected async Task OpenSolution(string path)
         {
 
-            _logger.WriteLine("Opening solution '{path}' ...");
+            WriteLog($"Opening solution '{path}' ...");
             Dte.Solution.Open(path);
 
             await Task.Delay(TimeSpan.FromSeconds(5));
-            _logger.WriteLine("Delay after solution open stopped.");
+            WriteLog("Delay after solution open stopped.");
         }
 
         protected void CloseSolution() => Dte.Solution.Close();

--- a/src/Cody.sln
+++ b/src/Cody.sln
@@ -24,6 +24,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		build.cake = build.cake
 		..\.github\workflows\cake-build.yml = ..\.github\workflows\cake-build.yml
 		..\.github\workflows\code-style.yml = ..\.github\workflows\code-style.yml
+		..\.github\workflows\nightly.yml = ..\.github\workflows\nightly.yml
 		..\.github\workflows\publish.yml = ..\.github\workflows\publish.yml
 		..\.github\workflows\release-preview.yml = ..\.github\workflows\release-preview.yml
 	EndProjectSection


### PR DESCRIPTION
Implemented ability to automatically take screenshots for UI tests, locally and when using GitHub Actions. A screenshot is taken at the end of every UI test (all tests inherited from `PlaywrightTestsBase` class).

Currently  `VsTestSettings(TakeScreenshotOnFailure = true)` attribute doesn't work for async tests (`Task async` or `void async`), which is way the custom solution was implemented.

- Updated Cake Build and Nightly Build to include support for taking screenshots via GitHub Actions.
- Additional logging for Solution_Name_Is_Added_To_Chat_Input(), which very rarely fails.
- Additional logging for PlaywrightTestsBase.GetChatContextTags()
- Fixed logging for TestBase.OpenSolution()
