### PR TITLE
Release 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## Security
 
+## [0.1.1]
+
+### Fixed
+
+- Login issue.
+
 ## [0.1.0]
 
 ### Added

--- a/src/Cody.VisualStudio/source.extension.vsixmanifest
+++ b/src/Cody.VisualStudio/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="Cody.VisualStudio" Version="0.1.0" Language="en-US" Publisher="sourcegraph" />
+        <Identity Id="Cody.VisualStudio" Version="0.1.1" Language="en-US" Publisher="sourcegraph" />
         <DisplayName>Cody for Visual Studio - AI Coding Assistant</DisplayName>
         <Description xml:space="preserve">AI coding assistant that uses search and codebase context to help you write code faster!</Description>
         <MoreInfo>https://sourcegraph.com/cody</MoreInfo>

--- a/src/build.cake
+++ b/src/build.cake
@@ -46,7 +46,7 @@ var nodeBinaryUrl = "https://github.com/sourcegraph/node-binaries/raw/main/v20.1
 var nodeArmBinaryUrl = "https://github.com/sourcegraph/node-binaries/raw/main/v20.12.2/node-win-arm64.exe";
 
 // The latest tag of the stable release from the cody repository https://github.com/sourcegraph/cody/tags
-var codyStableReleaseTag = "vscode-v1.40.0";
+var codyStableReleaseTag = "vscode-v1.38.3";
 var codyBranch = Argument("cody-branch", codyStableReleaseTag);
 
 var marketplaceToken = EnvironmentVariable("CODY_VS_MARKETPLACE_RELEASE_TOKEN");


### PR DESCRIPTION
- Update the extension version to 0.1.1 in the `source.extension.vsixmanifest` file
- Update the cody stable release tag to `vscode-v1.38.3` in the `build.cake` file
- Add a changelog entry for the 0.1.1 release, noting the fix for the login issue