### PR TITLE
Release 0.1.2 (#138)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## Security
 
+## [0.1.2]
+
+### Added
+
+- VS Code version 1.40.1.
+
 ## [0.1.1]
 
 ### Fixed

--- a/docs/dev/Release.md
+++ b/docs/dev/Release.md
@@ -1,4 +1,3 @@
-
 # Releases
 
 Version number format follows [Semantic Versioning](https://semver.org/) of <major>.<minor>.<patch>.
@@ -24,10 +23,7 @@ Follow these steps to publish a new release to the [Visual Studio Marketplace](h
 Include the following checklist in the PR description when creating a new release.
 
 ```markdown
-Release Checklist:
-    - [ ] Update version number
-    - [ ] Update [CHANGELOG.md](./CHANGELOG.md)
-    - [ ] Link to PR for the release blog post (if any)
+Release Checklist: - [ ] Update version number - [ ] Update [CHANGELOG.md](./CHANGELOG.md) - [ ] Link to PR for the release blog post (if any)
 ```
 
 Note: Ensure all checklist items are completed before merging the release PR.
@@ -46,6 +42,14 @@ To publish a **patch** release:
 6. Follow the steps for a stable release starting from step 2 to publish the patch release.
 
 IMPORTANT: You do not need to merge the patch branch back into `main` as it is a temporary branch. However, you will need to update the version number in the `main` branch after the patch release is published.
+
+## Rollback
+
+In case of a critical issue with the latest release, a rollback may be necessary. The new release should be published as soon as possible to replace the faulty release.
+
+However, rolling back a release is not a straightforward process. It requires a new release with a fix for the issue and a new version number, while the main Cody repository tag should be updated to the previous version.
+
+The rest of the release process remains the same as for a patch release.
 
 ## Nightly build
 

--- a/src/Cody.VisualStudio/source.extension.vsixmanifest
+++ b/src/Cody.VisualStudio/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="Cody.VisualStudio" Version="0.1.1" Language="en-US" Publisher="sourcegraph" />
+        <Identity Id="Cody.VisualStudio" Version="0.1.2" Language="en-US" Publisher="sourcegraph" />
         <DisplayName>Cody for Visual Studio - AI Coding Assistant</DisplayName>
         <Description xml:space="preserve">AI coding assistant that uses search and codebase context to help you write code faster!</Description>
         <MoreInfo>https://sourcegraph.com/cody</MoreInfo>

--- a/src/build.cake
+++ b/src/build.cake
@@ -46,7 +46,7 @@ var nodeBinaryUrl = "https://github.com/sourcegraph/node-binaries/raw/main/v20.1
 var nodeArmBinaryUrl = "https://github.com/sourcegraph/node-binaries/raw/main/v20.12.2/node-win-arm64.exe";
 
 // The latest tag of the stable release from the cody repository https://github.com/sourcegraph/cody/tags
-var codyStableReleaseTag = "vscode-v1.38.3";
+var codyStableReleaseTag = "vscode-v1.40.1";
 var codyBranch = Argument("cody-branch", codyStableReleaseTag);
 
 var marketplaceToken = EnvironmentVariable("CODY_VS_MARKETPLACE_RELEASE_TOKEN");


### PR DESCRIPTION
- Update extension version to 0.1.2
- Update the Cody stable release tag to `vscode-v1.40.1` in the `build.cake` file
- docs: Add changelog entry for the 0.1.2 release, noting the update to VS Code version 1.40.1

# NOTE: Only merge this and follow the release docs to cut the release once 1.40.1 is available