### PR TITLE
Add repository controls

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,5 @@
+
+
+## Test plan
+
+<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->

--- a/.github/workflows/pr-auditor.yml
+++ b/.github/workflows/pr-auditor.yml
@@ -1,0 +1,27 @@
+name: pr-auditor
+on:
+  pull_request_target:
+    types: [ closed, edited, opened, synchronize, ready_for_review ]
+
+
+jobs:
+  check-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: 'sourcegraph/devx-service'
+          token: ${{ secrets.PR_AUDITOR_TOKEN }}
+      - uses: actions/setup-go@v4
+        with: { go-version: '1.22' }
+
+      - run: 'go run ./cmd/pr-auditor'
+        env:
+          GITHUB_EVENT_PATH: ${{ env.GITHUB_EVENT_PATH }}
+          GITHUB_TOKEN: ${{ secrets.PR_AUDITOR_TOKEN }}
+          GITHUB_RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+  report_failure:
+    needs: check-pr
+    if: ${{ failure() }}
+    uses: sourcegraph/workflows/.github/workflows/report-job-failure.yml@main
+    secrets: inherit

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,55 @@
+name: Semgrep - SAST Scan
+
+on:
+  pull_request_target:
+    types: [ closed, edited, opened, synchronize, ready_for_review ]
+
+jobs:
+  semgrep:
+    permissions:
+      contents: read
+      actions: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    container:
+      image: returntocorp/semgrep
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+
+      - name: Checkout semgrep-rules repo
+        uses: actions/checkout@v3
+        with:
+          repository: sourcegraph/security-semgrep-rules
+          token: ${{ secrets.GH_SEMGREP_SAST_TOKEN }}
+          path: semgrep-rules 
+
+      - name: Run Semgrep SAST Scan
+        run: |
+          mv semgrep-rules ../
+          semgrep ci -f ../semgrep-rules/semgrep-rules/ --metrics=off --oss-only --suppress-errors --json -o result.json --verbose --baseline-commit "$(git merge-base main HEAD)" || true
+
+      - uses: actions/setup-go@v4
+        with: { go-version: '1.21' }
+
+      - name: set env
+        run: |
+          echo "LATEST_COMMIT_SHA=$(git rev-parse HEAD)" >> $GITHUB_ENV
+
+      - name: Semgrep post processing step
+        env:
+          SEMGREP_GITHUB_APP_PRIVATE_KEY: ${{ secrets.SEMGREP_GITHUB_APP_PRIVATE_KEY }}
+          SEMGREPSAST_VERIFY_TOKEN: ${{ secrets.SEMGREPSAST_VERIFY_TOKEN }}
+          GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
+          GITHUB_REPOSITORY: ${{ github.event.repository.name }}
+          GITHUB_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
+          GITHUB_SHA: ${{ github.sha }}
+        run: |
+          cp result.json ../semgrep-rules/scripts/result.json
+          cd ..
+          cd semgrep-rules/scripts
+          go mod download
+          go run main.go

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -7,49 +7,31 @@ on:
 jobs:
   semgrep:
     permissions:
-      contents: read
-      actions: read
-      pull-requests: write
+      contents: read # for actions/checkout to fetch code
+      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
     runs-on: ubuntu-latest
     container:
       image: returntocorp/semgrep
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Checkout semgrep-rules repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: sourcegraph/security-semgrep-rules
           token: ${{ secrets.GH_SEMGREP_SAST_TOKEN }}
-          path: semgrep-rules 
+          path: semgrep-rules
 
       - name: Run Semgrep SAST Scan
         run: |
           mv semgrep-rules ../
-          semgrep ci -f ../semgrep-rules/semgrep-rules/ --metrics=off --oss-only --suppress-errors --json -o result.json --verbose --baseline-commit "$(git merge-base main HEAD)" || true
-
-      - uses: actions/setup-go@v4
-        with: { go-version: '1.21' }
-
-      - name: set env
-        run: |
-          echo "LATEST_COMMIT_SHA=$(git rev-parse HEAD)" >> $GITHUB_ENV
-
-      - name: Semgrep post processing step
-        env:
-          SEMGREP_GITHUB_APP_PRIVATE_KEY: ${{ secrets.SEMGREP_GITHUB_APP_PRIVATE_KEY }}
-          SEMGREPSAST_VERIFY_TOKEN: ${{ secrets.SEMGREPSAST_VERIFY_TOKEN }}
-          GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
-          GITHUB_REPOSITORY: ${{ github.event.repository.name }}
-          GITHUB_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
-          GITHUB_SHA: ${{ github.sha }}
-        run: |
-          cp result.json ../semgrep-rules/scripts/result.json
-          cd ..
-          cd semgrep-rules/scripts
-          go mod download
-          go run main.go
+          semgrep ci -f ../semgrep-rules/semgrep-rules/ --metrics=off --oss-only --suppress-errors --sarif -o results.sarif --exclude='semgrep-rules' --baseline-commit "$(git merge-base main HEAD)" || true
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
This PR adds two GH actions in order to comply with [Sourcegraph Repository Controls](https://www.notion.so/sourcegraph/Repository-policies-and-controls-0e9d5ae3ef4949b3bf0de48b247dc7d3):
- pr-auditor ensures that the PR has a Test Plan
- semgrep is our SAST tool

closes https://linear.app/sourcegraph/issue/SEC-2167/review-vs-repo-controls