### PR TITLE
Cody agent updated to version vscode-v1.44.0 (tag)

### DIFF
--- a/agent/agent.version
+++ b/agent/agent.version
@@ -1,1 +1,1 @@
-vscode-v1.42.x
+vscode-v1.46.x

--- a/agent/agent.version
+++ b/agent/agent.version
@@ -1,1 +1,1 @@
-vscode-v1.46.x
+vscode-v1.44.0

--- a/src/Cody.sln
+++ b/src/Cody.sln
@@ -21,6 +21,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Cody.AgentTester", "Cody.Ag
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{D606EDCF-C31F-4C52-B8E7-68F87CCF91CF}"
 	ProjectSection(SolutionItems) = preProject
+		..\agent\agent.version = ..\agent\agent.version
 		..\.github\workflows\build.yml = ..\.github\workflows\build.yml
 		..\.github\workflows\code-style.yml = ..\.github\workflows\code-style.yml
 		..\.github\workflows\nightly.yml = ..\.github\workflows\nightly.yml


### PR DESCRIPTION
CLOSE https://linear.app/sourcegraph/issue/CODY-4360/bump-vs-to-use-cody-v146x