### PR TITLE
UI tests improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build and test extension
 
 on:
   push:
-    branches: [main]
+    branches: [main/uitests-ci-improvements-v3]
   pull_request:
     branches: [main]
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build and test extension
 
 on:
   push:
-    branches: [piotr/uitests-ci-improvements-v3]
+    branches: [main]
   pull_request:
     branches: [main]
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build and test extension
 
 on:
   push:
-    branches: [main/uitests-ci-improvements-v3]
+    branches: [piotr/uitests-ci-improvements-v3]
   pull_request:
     branches: [main]
 

--- a/src/Cody.VisualStudio.Tests/ChatLoggedBasicTests.cs
+++ b/src/Cody.VisualStudio.Tests/ChatLoggedBasicTests.cs
@@ -69,14 +69,11 @@ namespace Cody.VisualStudio.Tests
             await WaitForPlaywrightAsync();
 
             await EnterChatTextAndSend(prompt);
-            //await CloseCodyChatToolWindow();
 
-            //await OpenCodyChatToolWindow();
             await ShowHistoryTab();
             var chatHistoryEntries = await GetTodayChatHistory();
 
             Assert.Contains(chatHistoryEntries, x => x.Contains(prompt));
-
         }
 
         public void Dispose()

--- a/src/Cody.VisualStudio.Tests/ChatLoggedBasicTests.cs
+++ b/src/Cody.VisualStudio.Tests/ChatLoggedBasicTests.cs
@@ -69,6 +69,7 @@ namespace Cody.VisualStudio.Tests
             var prompt = $"How to create const with value {num}?";
 
             await WaitForPlaywrightAsync();
+            TakeScreenshot($"{GetTestName()}_1");
 
             await EnterChatTextAndSend(prompt);
 

--- a/src/Cody.VisualStudio.Tests/ChatLoggedBasicTests.cs
+++ b/src/Cody.VisualStudio.Tests/ChatLoggedBasicTests.cs
@@ -60,7 +60,7 @@ namespace Cody.VisualStudio.Tests
             Assert.True(isOpen);
         }
 
-        //[VsFact(Version = VsVersion.VS2022)]
+        [VsFact(Version = VsVersion.VS2022)]
         public async Task Entered_Prompt_Show_Up_In_Today_History()
         {
             var num = new Random().Next();
@@ -69,9 +69,9 @@ namespace Cody.VisualStudio.Tests
             await WaitForPlaywrightAsync();
 
             await EnterChatTextAndSend(prompt);
-            await CloseCodyChatToolWindow();
+            //await CloseCodyChatToolWindow();
 
-            await OpenCodyChatToolWindow();
+            //await OpenCodyChatToolWindow();
             await ShowHistoryTab();
             var chatHistoryEntries = await GetTodayChatHistory();
 

--- a/src/Cody.VisualStudio.Tests/ChatLoggedBasicTests.cs
+++ b/src/Cody.VisualStudio.Tests/ChatLoggedBasicTests.cs
@@ -91,7 +91,6 @@ namespace Cody.VisualStudio.Tests
             var prompt = $"How to create const with value {num}?";
 
             await WaitForPlaywrightAsync();
-            TakeScreenshot($"{GetTestName()}_1");
 
             await EnterChatTextAndSend(prompt);
 

--- a/src/Cody.VisualStudio.Tests/ChatLoggedBasicTests.cs
+++ b/src/Cody.VisualStudio.Tests/ChatLoggedBasicTests.cs
@@ -49,6 +49,28 @@ namespace Cody.VisualStudio.Tests
         }
 
         [VsFact(Version = VsVersion.VS2022)]
+        public async Task Active_File_Match_Current_Chat_Context()
+        {
+            // given
+            await WaitForPlaywrightAsync();
+            await NewChat();
+
+            await OpenSolution(SolutionsPaths.GetConsoleApp1File("ConsoleApp1.sln"));
+
+            // when
+            const int startLine = 2; const int endLine = 3;
+            await OpenDocument(SolutionsPaths.GetConsoleApp1File(@"ConsoleApp1\Program.cs"), startLine, endLine);
+            var tags = await GetChatContextTags();
+
+            // then
+            var firstTagName = tags.First().Name;
+            var secondTag = tags.ElementAt(1);
+            Assert.Equal("Program.cs", firstTagName);
+            Assert.Equal(startLine, secondTag.StartLine);
+            Assert.Equal(endLine, secondTag.EndLine);
+        }
+
+        [VsFact(Version = VsVersion.VS2022)]
         public async Task Can_Chat_Tool_Window_Be_Closed_And_Opened_Again()
         {
             await WaitForPlaywrightAsync();

--- a/src/Cody.VisualStudio.Tests/ChatLoggedBasicTests.cs
+++ b/src/Cody.VisualStudio.Tests/ChatLoggedBasicTests.cs
@@ -31,6 +31,8 @@ namespace Cody.VisualStudio.Tests
         {
             // given
             await WaitForPlaywrightAsync();
+            await NewChat();
+
             await OpenSolution(SolutionsPaths.GetConsoleApp1File("ConsoleApp1.sln"));
 
             // when

--- a/src/Cody.VisualStudio.Tests/PlaywrightTestsBase.cs
+++ b/src/Cody.VisualStudio.Tests/PlaywrightTestsBase.cs
@@ -189,6 +189,8 @@ namespace Cody.VisualStudio.Tests
             }
             await Task.Delay(500);
 
+            await DismissStartWindow();
+
             TakeScreenshot($"{GetTestName()}_3");
         }
 

--- a/src/Cody.VisualStudio.Tests/PlaywrightTestsBase.cs
+++ b/src/Cody.VisualStudio.Tests/PlaywrightTestsBase.cs
@@ -158,15 +158,31 @@ namespace Cody.VisualStudio.Tests
 
         protected async Task EnterChatTextAndSend(string prompt)
         {
-            var entryArea = Page.Locator("[data-keep-toolbar-open=true]").Last;
+            var entryArea = Page.Locator("span[data-lexical-text='true']");
 
-            await entryArea.PressSequentiallyAsync(prompt);
+            TakeScreenshot($"{GetTestName()}_2");
+
+            await entryArea.FillAsync(prompt);
+            //await entryArea.PressSequentiallyAsync(prompt);
+
+            TakeScreenshot($"{GetTestName()}_3");
+
             await entryArea.PressAsync("Enter");
+
+            TakeScreenshot($"{GetTestName()}_4");
 
             var button = await Page.WaitForSelectorAsync("menu button[type=submit][title=Stop]");
 
-            while (await button.GetAttributeAsync("title") == "Stop") await Task.Delay(500);
+            TakeScreenshot($"{GetTestName()}_5");
+
+            while (await button.GetAttributeAsync("title") == "Stop")
+            {
+                TakeScreenshot($"{GetTestName()}_6");
+                await Task.Delay(500);
+            }
             await Task.Delay(500);
+
+            TakeScreenshot($"{GetTestName()}_7");
         }
 
         protected async Task<string[]> GetTodayChatHistory()

--- a/src/Cody.VisualStudio.Tests/PlaywrightTestsBase.cs
+++ b/src/Cody.VisualStudio.Tests/PlaywrightTestsBase.cs
@@ -142,7 +142,11 @@ namespace Cody.VisualStudio.Tests
             Assert.Equal(text, textContents.First());
         }
 
-        protected async Task ShowChatTab() => await Page.GetByTestId("tab-chat").ClickAsync();
+        protected async Task ShowChatTab()
+        {
+            await Page.GetByTestId("tab-chat").ClickAsync();
+            await Task.Delay(500);
+        }
 
         protected async Task ShowHistoryTab()
         {

--- a/src/Cody.VisualStudio.Tests/PlaywrightTestsBase.cs
+++ b/src/Cody.VisualStudio.Tests/PlaywrightTestsBase.cs
@@ -150,7 +150,9 @@ namespace Cody.VisualStudio.Tests
 
         protected async Task NewChat()
         {
-            await Page.GetByText("New Chat").ClickAsync();
+            //await Page.GetByText("New Chat").ClickAsync();
+            await Page.GetByRole(AriaRole.Button, new PageGetByRoleOptions {Name = "New Chat"}).ClickAsync();
+
             await Task.Delay(500);
         }
 

--- a/src/Cody.VisualStudio.Tests/PlaywrightTestsBase.cs
+++ b/src/Cody.VisualStudio.Tests/PlaywrightTestsBase.cs
@@ -187,6 +187,8 @@ namespace Cody.VisualStudio.Tests
         {
             var todaySection = await Page.QuerySelectorAsync("div[id='history-today-content']");
 
+            TakeScreenshot($"{GetTestName()}_1");
+
             return (await todaySection.QuerySelectorAllAsync("button span"))
                 .Select(async x => await x.TextContentAsync())
                 .Select(x => x.Result)

--- a/src/Cody.VisualStudio.Tests/PlaywrightTestsBase.cs
+++ b/src/Cody.VisualStudio.Tests/PlaywrightTestsBase.cs
@@ -156,8 +156,13 @@ namespace Cody.VisualStudio.Tests
 
         protected async Task ShowHistoryTab()
         {
+
+            TakeScreenshot($"{GetTestName()}_4");
+
             await Page.GetByTestId("tab-history").ClickAsync();
             await Task.Delay(500);
+
+            TakeScreenshot($"{GetTestName()}_5");
         }
 
         protected async Task ShowPromptsTab() => await Page.GetByTestId("tab-prompts").ClickAsync();
@@ -174,6 +179,8 @@ namespace Cody.VisualStudio.Tests
             await entryArea.FillAsync(prompt);
             await enterArea.PressAsync("Enter");
 
+            TakeScreenshot($"{GetTestName()}_2");
+
             var isStopVisible = false; 
             while (!isStopVisible)
             {
@@ -181,13 +188,17 @@ namespace Cody.VisualStudio.Tests
                 await Task.Delay(500);
             }
             await Task.Delay(500);
+
+            TakeScreenshot($"{GetTestName()}_3");
         }
 
         protected async Task<string[]> GetTodayChatHistory()
         {
+            TakeScreenshot($"{GetTestName()}_6");
+
             var todaySection = await Page.QuerySelectorAsync("div[id='history-today-content']");
 
-            TakeScreenshot($"{GetTestName()}_1");
+            TakeScreenshot($"{GetTestName()}_7");
 
             return (await todaySection.QuerySelectorAllAsync("button span"))
                 .Select(async x => await x.TextContentAsync())

--- a/src/Cody.VisualStudio.Tests/PlaywrightTestsBase.cs
+++ b/src/Cody.VisualStudio.Tests/PlaywrightTestsBase.cs
@@ -159,6 +159,7 @@ namespace Cody.VisualStudio.Tests
         protected async Task EnterChatTextAndSend(string prompt)
         {
             var entryArea = Page.Locator("span[data-lexical-text='true']");
+            var enterArea = Page.Locator("[data-keep-toolbar-open=true]").Last;
 
             TakeScreenshot($"{GetTestName()}_2");
 
@@ -167,7 +168,8 @@ namespace Cody.VisualStudio.Tests
 
             TakeScreenshot($"{GetTestName()}_3");
 
-            await entryArea.PressAsync("Enter");
+            await enterArea.PressAsync("Enter");
+            //await entryArea.PressAsync("Enter");
 
             TakeScreenshot($"{GetTestName()}_4");
 
@@ -175,9 +177,11 @@ namespace Cody.VisualStudio.Tests
 
             TakeScreenshot($"{GetTestName()}_5");
 
-            while (await button.GetAttributeAsync("title") == "Stop")
+            var isStopVisible = false; 
+            while (!isStopVisible)
             {
                 TakeScreenshot($"{GetTestName()}_6");
+                isStopVisible = await Page.Locator("vscode-button").First.IsVisibleAsync();
                 await Task.Delay(500);
             }
             await Task.Delay(500);

--- a/src/Cody.VisualStudio.Tests/PlaywrightTestsBase.cs
+++ b/src/Cody.VisualStudio.Tests/PlaywrightTestsBase.cs
@@ -161,32 +161,16 @@ namespace Cody.VisualStudio.Tests
             var entryArea = Page.Locator("span[data-lexical-text='true']");
             var enterArea = Page.Locator("[data-keep-toolbar-open=true]").Last;
 
-            TakeScreenshot($"{GetTestName()}_2");
-
             await entryArea.FillAsync(prompt);
-            //await entryArea.PressSequentiallyAsync(prompt);
-
-            TakeScreenshot($"{GetTestName()}_3");
-
             await enterArea.PressAsync("Enter");
-            //await entryArea.PressAsync("Enter");
-
-            TakeScreenshot($"{GetTestName()}_4");
-
-            var button = await Page.WaitForSelectorAsync("menu button[type=submit][title=Stop]");
-
-            TakeScreenshot($"{GetTestName()}_5");
 
             var isStopVisible = false; 
             while (!isStopVisible)
             {
-                TakeScreenshot($"{GetTestName()}_6");
                 isStopVisible = await Page.Locator("vscode-button").First.IsVisibleAsync();
                 await Task.Delay(500);
             }
             await Task.Delay(500);
-
-            TakeScreenshot($"{GetTestName()}_7");
         }
 
         protected async Task<string[]> GetTodayChatHistory()

--- a/src/Cody.VisualStudio.Tests/PlaywrightTestsBase.cs
+++ b/src/Cody.VisualStudio.Tests/PlaywrightTestsBase.cs
@@ -186,6 +186,7 @@ namespace Cody.VisualStudio.Tests
         protected async Task<IReadOnlyCollection<ContextTag>> GetChatContextTags()
         {
             var tagsList = new List<ContextTag>();
+            await ShowChatTab();
 
             WriteLog("Searching for Chat ...");
             var chatBox = await Page.QuerySelectorAsync("[aria-label='Chat message']");

--- a/src/Cody.VisualStudio.Tests/PlaywrightTestsBase.cs
+++ b/src/Cody.VisualStudio.Tests/PlaywrightTestsBase.cs
@@ -148,6 +148,12 @@ namespace Cody.VisualStudio.Tests
             await Task.Delay(500);
         }
 
+        protected async Task NewChat()
+        {
+            await Page.GetByText("New Chat").ClickAsync();
+            await Task.Delay(500);
+        }
+
         protected async Task ShowHistoryTab()
         {
             await Page.GetByTestId("tab-history").ClickAsync();

--- a/src/Cody.VisualStudio.Tests/PlaywrightTestsBase.cs
+++ b/src/Cody.VisualStudio.Tests/PlaywrightTestsBase.cs
@@ -150,7 +150,6 @@ namespace Cody.VisualStudio.Tests
 
         protected async Task NewChat()
         {
-            //await Page.GetByText("New Chat").ClickAsync();
             await Page.GetByRole(AriaRole.Button, new PageGetByRoleOptions {Name = "New Chat"}).ClickAsync();
 
             await Task.Delay(500);
@@ -191,7 +190,7 @@ namespace Cody.VisualStudio.Tests
             }
             await Task.Delay(500);
 
-            //await DismissStartWindow();
+            await DismissStartWindow();
 
             TakeScreenshot($"{GetTestName()}_3");
         }

--- a/src/Cody.VisualStudio.Tests/PlaywrightTestsBase.cs
+++ b/src/Cody.VisualStudio.Tests/PlaywrightTestsBase.cs
@@ -189,7 +189,7 @@ namespace Cody.VisualStudio.Tests
             }
             await Task.Delay(500);
 
-            await DismissStartWindow();
+            //await DismissStartWindow();
 
             TakeScreenshot($"{GetTestName()}_3");
         }

--- a/src/Cody.VisualStudio.Tests/PlaywrightTestsBase.cs
+++ b/src/Cody.VisualStudio.Tests/PlaywrightTestsBase.cs
@@ -157,13 +157,8 @@ namespace Cody.VisualStudio.Tests
 
         protected async Task ShowHistoryTab()
         {
-
-            TakeScreenshot($"{GetTestName()}_4");
-
             await Page.GetByTestId("tab-history").ClickAsync();
             await Task.Delay(500);
-
-            TakeScreenshot($"{GetTestName()}_5");
         }
 
         protected async Task ShowPromptsTab() => await Page.GetByTestId("tab-prompts").ClickAsync();
@@ -180,8 +175,6 @@ namespace Cody.VisualStudio.Tests
             await entryArea.FillAsync(prompt);
             await enterArea.PressAsync("Enter");
 
-            TakeScreenshot($"{GetTestName()}_2");
-
             var isStopVisible = false; 
             while (!isStopVisible)
             {
@@ -191,17 +184,11 @@ namespace Cody.VisualStudio.Tests
             await Task.Delay(500);
 
             await DismissStartWindow();
-
-            TakeScreenshot($"{GetTestName()}_3");
         }
 
         protected async Task<string[]> GetTodayChatHistory()
         {
-            TakeScreenshot($"{GetTestName()}_6");
-
             var todaySection = await Page.QuerySelectorAsync("div[id='history-today-content']");
-
-            TakeScreenshot($"{GetTestName()}_7");
 
             return (await todaySection.QuerySelectorAllAsync("button span"))
                 .Select(async x => await x.TextContentAsync())

--- a/src/Cody.VisualStudio/Services/ThemeService.cs
+++ b/src/Cody.VisualStudio/Services/ThemeService.cs
@@ -130,10 +130,14 @@ namespace Cody.VisualStudio.Services
 
             // Generate the CSS variables for the fonts.
             var editorFont = GetEditorFont();
+            _logger.Debug($"Detected editor font:{editorFont.FontName} size:{editorFont.Size}");
+
             sb.AppendLine($"rootStyle.setProperty('--visualstudio-editor-font-family', '{editorFont.FontName}');");
             sb.AppendLine($"rootStyle.setProperty('--visualstudio-editor-font-size', '{editorFont.Size}pt');");
 
             var uiFont = GetUIFont();
+            _logger.Debug($"Detected UI font:{uiFont.FontName} size:{uiFont.Size}");
+
             sb.AppendLine($"rootStyle.setProperty('--visualstudio-ui-font-family', '{uiFont.FontName}');");
             sb.AppendLine($"rootStyle.setProperty('--visualstudio-ui-font-size', '{uiFont.Size}pt');");
 


### PR DESCRIPTION
CLOSE https://linear.app/sourcegraph/issue/CODY-4322/make-entered-prompt-show-up-in-today-history-working-in-the-ci

- Entered_Prompt_Show_Up_In_Today_History() is finally working
- New test  Active_File_Match_Current_Chat_Context()
- Added NewChat() method
- Added delay to ShowChatTab() method
- DismissStartWindow() method called at the of EnterChatTextAndSend() because VS modal dialog for selecting project is showing up in the foreground for some reason
