### PR TITLE
Improved handling for VS Start Window during UI tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build and test extension
 
 on:
   push:
-    branches: [main]
+    branches: [piotr/dismiss-start-window-v2]
   pull_request:
     branches: [main]
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build and test extension
 
 on:
   push:
-    branches: [piotr/dismiss-start-window-v2]
+    branches: [main]
   pull_request:
     branches: [main]
 

--- a/src/Cody.VisualStudio.Tests/ChatLoggedBasicTests.cs
+++ b/src/Cody.VisualStudio.Tests/ChatLoggedBasicTests.cs
@@ -10,6 +10,8 @@ namespace Cody.VisualStudio.Tests
     {
         public ChatLoggedBasicTests(ITestOutputHelper output) : base(output)
         {
+            var testName = $"{GetTestName()}_start";
+            TakeScreenshot(testName);
         }
 
         [VsFact(Version = VsVersion.VS2022)]
@@ -102,7 +104,7 @@ namespace Cody.VisualStudio.Tests
 
         public void Dispose()
         {
-            var testName = GetTestName();
+            var testName = $"{GetTestName()}_end";
             TakeScreenshot(testName);
         }
     }

--- a/src/Cody.VisualStudio.Tests/ChatLoggedBasicTests.cs
+++ b/src/Cody.VisualStudio.Tests/ChatLoggedBasicTests.cs
@@ -1,3 +1,5 @@
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Threading;
 using System;
 using System.Linq;
 using System.Threading.Tasks;
@@ -8,17 +10,23 @@ namespace Cody.VisualStudio.Tests
 {
     public class ChatLoggedBasicTests : PlaywrightTestsBase, IDisposable
     {
+        private readonly JoinableTaskContext _context = ThreadHelper.JoinableTaskContext;
+
         public ChatLoggedBasicTests(ITestOutputHelper output) : base(output)
         {
             var testName = $"{GetTestName()}_start";
             TakeScreenshot(testName);
+
+            _context.Factory.Run(async () =>
+            {
+                await WaitForPlaywrightAsync();
+            });
         }
 
         [VsFact(Version = VsVersion.VS2022)]
         public async Task Solution_Name_Is_Added_To_Chat_Input()
         {
             // given
-            await WaitForPlaywrightAsync();
             await OpenSolution(SolutionsPaths.GetConsoleApp1File("ConsoleApp1.sln"));
 
             // when
@@ -32,7 +40,6 @@ namespace Cody.VisualStudio.Tests
         public async Task Active_File_Name_And_Line_Selection_Is_Showing_In_Chat_Input()
         {
             // given
-            await WaitForPlaywrightAsync();
             await NewChat();
 
             await OpenSolution(SolutionsPaths.GetConsoleApp1File("ConsoleApp1.sln"));
@@ -54,7 +61,6 @@ namespace Cody.VisualStudio.Tests
         public async Task Active_File_Match_Current_Chat_Context()
         {
             // given
-            await WaitForPlaywrightAsync();
             await NewChat();
 
             await OpenSolution(SolutionsPaths.GetConsoleApp1File("ConsoleApp1.sln"));
@@ -75,8 +81,6 @@ namespace Cody.VisualStudio.Tests
         [VsFact(Version = VsVersion.VS2022)]
         public async Task Can_Chat_Tool_Window_Be_Closed_And_Opened_Again()
         {
-            await WaitForPlaywrightAsync();
-
             await CloseCodyChatToolWindow();
             var isOpen = IsCodyChatToolWindowOpen();
             Assert.False(isOpen);
@@ -91,8 +95,6 @@ namespace Cody.VisualStudio.Tests
         {
             var num = new Random().Next();
             var prompt = $"How to create const with value {num}?";
-
-            await WaitForPlaywrightAsync();
 
             await EnterChatTextAndSend(prompt);
 

--- a/src/Cody.VisualStudio.Tests/Cody.VisualStudio.Tests.csproj
+++ b/src/Cody.VisualStudio.Tests/Cody.VisualStudio.Tests.csproj
@@ -34,6 +34,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="PresentationCore" />
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />

--- a/src/Cody.VisualStudio.Tests/PlaywrightTestsBase.cs
+++ b/src/Cody.VisualStudio.Tests/PlaywrightTestsBase.cs
@@ -109,7 +109,7 @@ namespace Cody.VisualStudio.Tests
                     {
                         WriteLog($"Found `{startWindow.GetType()}` window.");
                         startWindow.Hide();
-                        WriteLog($"`{startWindow.GetType()}` is hidden.");
+                        WriteLog($"`{startWindow.GetType()}` has been hidden.");
                     }
                 }
                 catch (Exception ex)

--- a/src/Cody.VisualStudio.Tests/PlaywrightTestsBase.cs
+++ b/src/Cody.VisualStudio.Tests/PlaywrightTestsBase.cs
@@ -105,7 +105,12 @@ namespace Cody.VisualStudio.Tests
                     }
 
                     var startWindow = GetQuickStartWindow();
-                    if (startWindow != null) startWindow.Hide();
+                    if (startWindow != null)
+                    {
+                        WriteLog($"Found `{startWindow.GetType()}` window.");
+                        startWindow.Hide();
+                        WriteLog($"`{startWindow.GetType()}` is hidden.");
+                    }
                 }
                 catch (Exception ex)
                 {

--- a/src/Cody.VisualStudio.Tests/PlaywrightTestsBase.cs
+++ b/src/Cody.VisualStudio.Tests/PlaywrightTestsBase.cs
@@ -4,12 +4,15 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Interop;
 using EnvDTE;
 using EnvDTE80;
 using Microsoft.Playwright;
 using Microsoft.VisualStudio.Shell;
 using Xunit;
 using Xunit.Abstractions;
+using Window = EnvDTE.Window;
 
 namespace Cody.VisualStudio.Tests
 {
@@ -93,12 +96,16 @@ namespace Cody.VisualStudio.Tests
                 {
                     var dte = (DTE2)Package.GetGlobalService(typeof(DTE));
                     var mainWindow = dte.MainWindow;
+
                     if (!mainWindow.Visible) // Options -> General -> On Startup open: Start Window
                     {
                         WriteLog("Main IDE Window NOT visible! Bringing it to the front ...");
                         mainWindow.Visible = true;
                         WriteLog("Main IDE Window is now VISIBLE.");
                     }
+
+                    var startWindow = GetQuickStartWindow();
+                    if (startWindow != null) startWindow.Hide();
                 }
                 catch (Exception ex)
                 {
@@ -110,6 +117,14 @@ namespace Cody.VisualStudio.Tests
 
                 return Task.CompletedTask;
             });
+        }
+
+        private System.Windows.Window GetQuickStartWindow()
+        {
+            return PresentationSource.CurrentSources.OfType<HwndSource>()
+                .Select(h => h.RootVisual)
+                .OfType<System.Windows.Window>()
+                .SingleOrDefault(w => w.GetType().Name == "QuickStartWindow");
         }
 
         protected async Task<string> GetAccessToken()


### PR DESCRIPTION
CLOSE https://linear.app/sourcegraph/issue/CODY-4471/improved-handling-for-vs-start-window-during-ui-tests

Refactored ChatLoggedBasicTests:
  - moved calls WaitForPlaywrightAsync() to constructor
  - added taking screenshots at the beginning of a test