### PR TITLE
Fixed not using original exception when logging error to Sentry

### DIFF
--- a/src/Cody.Core/Logging/Logger.cs
+++ b/src/Cody.Core/Logging/Logger.cs
@@ -62,7 +62,7 @@ namespace Cody.Core.Logging
             // TODO: _fileLogger.Error(customMessage);
             DebugWrite(customMessage);
             _outputWindowPane?.Error(message, callerName);
-            _sentryLog?.Error(message);
+            _sentryLog?.Error(customMessage);
             _testLogger?.WriteLog(message, "ERROR", callerName);
         }
 
@@ -84,7 +84,7 @@ namespace Cody.Core.Logging
             // TODO: _fileLogger.Error(originalException, customMessage);
             DebugWrite(customMessage);
             _outputWindowPane?.Error(outputMessage, callerName);
-            _sentryLog?.Error(ex);
+            _sentryLog?.Error(originalException);
             _testLogger?.WriteLog(message, "ERROR", callerName);
         }
 


### PR DESCRIPTION
CLOSE https://linear.app/sourcegraph/issue/CODY-4470/sentry-is-logging-inner-exception-instead-of-the-original-exception