### PR TITLE
Fixed agent cache issue when only single agent.version file was used to create agent cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build and test extension
 
 on:
   push:
-    branches: [piotr/agent-cache-fix]
+    branches: [main]
   pull_request:
     branches: [main]
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build and test extension
 
 on:
   push:
-    branches: [main]
+    branches: [piotr/agent-cache-fix]
   pull_request:
     branches: [main]
 
@@ -39,7 +39,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: src/Cody.VisualStudio/Agent
-          key: ${{ runner.os }}-agent-${{ hashFiles('agent/agent.version') }}  
+          key: ${{ runner.os }}-agent-${{ hashFiles('agent/agent.version', 'agent/buildAgent.ps1', 'agent/runBuildAgent.ps1') }}  
         
       - name: Build agent if needed
         if: ${{ steps.cache-agent.outputs.cache-hit != 'true' }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,7 +59,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: src/Cody.VisualStudio/Agent
-          key: ${{ runner.os }}-agent-${{ hashFiles('agent/agent.version') }}  
+          key: ${{ runner.os }}-agent-${{ hashFiles('agent/agent.version', 'agent/buildAgent.ps1', 'agent/runBuildAgent.ps1') }}  
         
       - name: Build agent if needed
         if: ${{ steps.cache-agent.outputs.cache-hit != 'true' }}


### PR DESCRIPTION
CLOSE https://linear.app/sourcegraph/issue/CODY-4472/cody-agent-is-cached-using-only-agentagentversion-file

Changes in the agent/buildAgent.ps1 and agent/runBuildAgent.ps1 don't trigger building agent, but they should.

Example - latest changes to buildAgent.ps1, like copying `agent.version` file to VSIX installer, didn't take effect because old cache from the agent was used. In this case call to `VersionService.GetAgentVersion()` fails.