### PR TITLE
Include index.js.map file in debug build

### DIFF
--- a/agent/buildAgent.ps1
+++ b/agent/buildAgent.ps1
@@ -22,7 +22,6 @@ $nodeArmUrl = "https://github.com/sourcegraph/node-binaries/raw/main/v20.12.2/no
 $exclude = @(
     "src",
     "scripts",
-    "*.map",
 	"noxide.linux*.node",
 	"noxide.darwin*.node",
     "tree-sitter-bash.wasm",

--- a/src/Cody.VisualStudio/Cody.VisualStudio.csproj
+++ b/src/Cody.VisualStudio/Cody.VisualStudio.csproj
@@ -99,6 +99,7 @@
       <IncludeInVSIX>true</IncludeInVSIX>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+	<Content Remove="Agent\index.js.map" Condition="'$(Configuration)' == 'Release'"/>
     <Content Include="Agent\webviews\*.*">
       <IncludeInVSIX>true</IncludeInVSIX>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/Cody.VisualStudio/source.extension.vsixmanifest
+++ b/src/Cody.VisualStudio/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="Cody.VisualStudio" Version="0.1.1" Language="en-US" Publisher="sourcegraph" />
+        <Identity Id="Cody.VisualStudio" Version="0.1.4" Language="en-US" Publisher="sourcegraph" />
         <DisplayName>Cody for Visual Studio - AI Coding Assistant</DisplayName>
         <Description xml:space="preserve">AI coding assistant that uses search and codebase context to help you write code faster!</Description>
         <MoreInfo>https://sourcegraph.com/cody</MoreInfo>


### PR DESCRIPTION
Index.js.map makes debugging the agent easier so it should be added to the debug build