### PR TITLE
Sentry enriching events and exception filtering

### DIFF
--- a/src/Cody.Core/Cody.Core.csproj
+++ b/src/Cody.Core/Cody.Core.csproj
@@ -91,6 +91,7 @@
     <Compile Include="Infrastructure\IProgressService.cs" />
     <Compile Include="Logging\ISentryLog.cs" />
     <Compile Include="Logging\ITestLogger.cs" />
+    <Compile Include="Logging\SentryExceptionFilter.cs" />
     <Compile Include="Logging\SentryLog.cs" />
     <Compile Include="Trace\FileTraceListener.cs" />
     <Compile Include="Trace\LogioTraceListener.cs" />

--- a/src/Cody.Core/Logging/SentryExceptionFilter.cs
+++ b/src/Cody.Core/Logging/SentryExceptionFilter.cs
@@ -1,0 +1,32 @@
+using Sentry.Extensibility;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Cody.Core.Logging
+{
+    public class SentryExceptionFilter : IExceptionFilter
+    {
+        public bool Filter(Exception ex)
+        {
+            //https://sourcegraph.sentry.io/issues/6123815161
+            if (ex is AggregateException &&
+                ex.InnerException != null &&
+                ex.InnerException is TimeoutException &&
+                ex.InnerException.TargetSite != null &&
+                ex.InnerException.TargetSite.DeclaringType.Name == "TplExtensions" &&
+                ex.InnerException.TargetSite?.Name == "WithTimeout") return false;
+
+            //https://sourcegraph.sentry.io/issues/6152558932
+            if(ex.TargetSite.DeclaringType.Assembly.FullName.StartsWith("JetBrains") ||
+               ex.InnerException != null && ex.InnerException.TargetSite.DeclaringType.Assembly.FullName.StartsWith("JetBrains")) return false;
+
+            //https://sourcegraph.sentry.io/issues/6115819359
+            if (ex.GetType().Name.StartsWith("JetBrains")) return false;
+
+            return true;
+        }
+    }
+}

--- a/src/Cody.Core/Logging/SentryLog.cs
+++ b/src/Cody.Core/Logging/SentryLog.cs
@@ -32,6 +32,7 @@ namespace Cody.Core.Logging
                     options.IsGlobalModeEnabled = true;
                     options.Environment = env;
                     options.Release = "cody-vs@" + version.ToString();
+                    options.AddExceptionFilter(new SentryExceptionFilter());
                 });
             }
         }

--- a/src/Cody.VisualStudio/CodyPackage.cs
+++ b/src/Cody.VisualStudio/CodyPackage.cs
@@ -23,6 +23,7 @@ using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Connected.CredentialStorage;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.TaskStatusCenter;
+using Sentry;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Design;
@@ -293,6 +294,15 @@ namespace Cody.VisualStudio
                 StatusbarService.SetText($"Hello {e.AuthStatus.DisplayName}! Press Alt + L to open Cody Chat.");
 
                 Logger.Info("Authenticated.");
+
+                SentrySdk.ConfigureScope(scope =>
+                {
+                    scope.User = new SentryUser
+                    {
+                        Email = e.AuthStatus.PrimaryEmail,
+                        Username = e.AuthStatus.Username,
+                    };
+                });
             }
             else
             {


### PR DESCRIPTION
- Sentry logs all errors from Visual Studio, not caring whether the errors originate in Cody or outside it. This PR limits the recording of the most common errors from outside the extension
- Enriching error information about the user

## Test plan
Watch for errors in Sentry to see if any new ones appear in:
https://sourcegraph.sentry.io/issues/6123815161
https://sourcegraph.sentry.io/issues/6152558932
https://sourcegraph.sentry.io/issues/6115819359
<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->
