### PR TITLE
Remove Sourcegraph URL option

### DIFF
--- a/src/Cody.UI/Controls/Options/GeneralOptionsControl.xaml
+++ b/src/Cody.UI/Controls/Options/GeneralOptionsControl.xaml
@@ -24,22 +24,6 @@
                     <ColumnDefinition Width="Auto" />
                 </Grid.ColumnDefinitions>
 
-                <!--Sourcegraph URL-->
-                <Label
-                    Grid.Row="0"
-                    Grid.Column="0"
-                    Content="Sourcegraph URL"
-                />
-
-                <TextBox
-                    Name="SourcegraphUrlTextBox"
-                    Grid.Row="0"
-                    Grid.Column="1"
-                    Width="400"
-                    Height="20"
-                    Text="{Binding SourcegraphUrl, Mode=TwoWay}"
-                    ToolTip="Enter the URL of the Sourcegraph instance. For example, https://sourcegraph.example.com"
-                />
 
                 <!--Custom Cody Configuration-->
                 <StackPanel
@@ -90,7 +74,7 @@
 
 
 
-                
+
             </Grid>
         </GroupBox>
     </Grid>

--- a/src/Cody.UI/Controls/Options/GeneralOptionsControl.xaml.cs
+++ b/src/Cody.UI/Controls/Options/GeneralOptionsControl.xaml.cs
@@ -16,7 +16,6 @@ namespace Cody.UI.Controls.Options
         {
             // TextBox binding doesn't work when Visual Studio closes Options window
             // This is a workaround to get bindings updated. The second solution is to use NotifyPropertyChange for every TextBox in the Xaml, but current solution is a little more "clean" - everything is clearly visible in a one place.
-            SourcegraphUrlTextBox.GetBindingExpression(TextBox.TextProperty)?.UpdateSource();
             CustomConfigurationTextBox.GetBindingExpression(TextBox.TextProperty)?.UpdateSource();
         }
     }

--- a/src/Cody.UI/ViewModels/GeneralOptionsViewModel.cs
+++ b/src/Cody.UI/ViewModels/GeneralOptionsViewModel.cs
@@ -52,19 +52,6 @@ namespace Cody.UI.ViewModels
             }
         }
 
-        private string _sourcegraphUrl;
-        public string SourcegraphUrl
-        {
-            get => _sourcegraphUrl;
-            set
-            {
-                if (SetProperty(ref _sourcegraphUrl, value))
-                {
-                    _logger.Debug($"Sourcegraph Url set:{SourcegraphUrl}");
-                }
-            }
-        }
-
         private bool _acceptNonTrustedCert;
         public bool AcceptNonTrustedCert
         {

--- a/src/Cody.VisualStudio/Options/GeneralOptionsPage.cs
+++ b/src/Cody.VisualStudio/Options/GeneralOptionsPage.cs
@@ -58,10 +58,8 @@ namespace Cody.VisualStudio.Options
             _logger.Debug($"Settings page activated.");
 
             var customConfiguration = _settingsService.CustomConfiguration;
-            var sourcegraphUrl = _settingsService.ServerEndpoint;
             var acceptNonTrustedCert = _settingsService.AcceptNonTrustedCert;
 
-            _generalOptionsViewModel.SourcegraphUrl = sourcegraphUrl;
             _generalOptionsViewModel.AcceptNonTrustedCert = acceptNonTrustedCert;
             _generalOptionsViewModel.CustomConfiguration = customConfiguration;
 
@@ -74,11 +72,9 @@ namespace Cody.VisualStudio.Options
             _logger.Debug($"{args.ApplyBehavior}");
 
             var customConfiguration = _generalOptionsViewModel.CustomConfiguration;
-            var sourcegraphUrl = _generalOptionsViewModel.SourcegraphUrl;
             var acceptNonTrustedCert = _generalOptionsViewModel.AcceptNonTrustedCert;
 
             _settingsService.CustomConfiguration = customConfiguration;
-            _settingsService.ServerEndpoint = sourcegraphUrl;
             _settingsService.AcceptNonTrustedCert = acceptNonTrustedCert;
         }
 
@@ -99,7 +95,6 @@ namespace Cody.VisualStudio.Options
         public override void ResetSettings()
         {
             _settingsService.CustomConfiguration = string.Empty;
-            _settingsService.ServerEndpoint = string.Empty;
             _settingsService.AcceptNonTrustedCert = false;
 
             base.ResetSettings();


### PR DESCRIPTION
This PR removes the 'Sourcegraph URL' option from the settings window because it has become part of the new login screen.

## Test plan
Check if the option is unavailable in the settings window.
<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->
