### PR TITLE
Reporting Visual Studio version to Sentry

### DIFF
--- a/src/Cody.Core/Logging/SentryLog.cs
+++ b/src/Cody.Core/Logging/SentryLog.cs
@@ -40,6 +40,7 @@ namespace Cody.Core.Logging
                     {
                         if (se.Exception?.Source?.StartsWith(CodyAssemblyPrefix) ?? false) return se;
                         if (se.Exception?.InnerException?.Source?.StartsWith(CodyAssemblyPrefix) ?? false) return se;
+                        if (se.Message != null) return se;
                         if (se.SentryExceptions == null) return se;
 
                         foreach(var ex in se.SentryExceptions)

--- a/src/Cody.VisualStudio/CodyPackage.cs
+++ b/src/Cody.VisualStudio/CodyPackage.cs
@@ -96,6 +96,7 @@ namespace Cody.VisualStudio
 
                 InitializeAgent();
 
+                ReportSentryVsVersion();
             }
             catch (Exception ex)
             {
@@ -144,6 +145,15 @@ namespace Cody.VisualStudio
             VsUIShell = this.GetService<SVsUIShell, IVsUIShell>();
 
             Logger.Info($"Visual Studio version: {VsVersionService.DisplayVersion} ({VsVersionService.EditionName})");
+        }
+
+        private void ReportSentryVsVersion()
+        {
+            SentrySdk.ConfigureScope(scope =>
+            {
+                scope.SetTag("vs", VsVersionService.DisplayVersion);
+                SentrySdk.CaptureMessage("Initialized");
+            });
         }
 
         private static void InitializeTrace()


### PR DESCRIPTION
Added tag "vs" which includes Visual Studio version when reporting errors:
- during initialization VS version is reported independently by sending `Initialized` message


## Test plan

Turn on logging for dev environment in the `SentryLog` class, and check if `Initialized` is properly logged in the Sentry Dashboard.
