### PR TITLE
feat(agent): add shell capability support

### DIFF
--- a/src/Cody.AgentTester/Program.cs
+++ b/src/Cody.AgentTester/Program.cs
@@ -79,6 +79,7 @@ namespace Cody.AgentTester
                     WebviewMessages = "string-encoded",
                     GlobalState = "stateless",
                     Secrets = "stateless",
+                    Shell = Capability.Enabled,
                 },
                 ExtensionConfiguration = new ExtensionConfiguration
                 {

--- a/src/Cody.Core/Agent/Protocol/ClientCapabilities.cs
+++ b/src/Cody.Core/Agent/Protocol/ClientCapabilities.cs
@@ -9,6 +9,7 @@ namespace Cody.Core.Agent.Protocol
         public Capability? Edit { get; set; }
         public Capability? EditWorkspace { get; set; }
         public Capability? UntitledDocuments { get; set; }
+        public Capability? Shell { get; set; }
         public Capability? ShowDocument { get; set; }
         public Capability? CodeLenses { get; set; }
         public ShowWindowMessageCapability? ShowWindowMessage { get; set; }

--- a/src/Cody.Core/Infrastructure/ConfigurationService.cs
+++ b/src/Cody.Core/Infrastructure/ConfigurationService.cs
@@ -43,6 +43,7 @@ namespace Cody.Core.Infrastructure
                     EditWorkspace = Capability.None,
                     ProgressBars = Capability.Enabled,
                     CodeLenses = Capability.None,
+                    Shell = Capability.Enabled,
                     ShowDocument = Capability.Enabled,
                     Ignore = Capability.Enabled,
                     UntitledDocuments = Capability.None,


### PR DESCRIPTION
Enabling terminal capability in Visual Studio for testing agentic chat: https://sourcegraph.com/github.com/sourcegraph/cody@main/-/blob/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/ClientCapabilities.kt?L22

![image](https://github.com/user-attachments/assets/4b12a02d-f172-490e-b0a5-6c290d60bc3b)

## Test plan

<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->

- Create a new solution
- Start adding code
- Check if shell commands can be executed
- Verify that the shell capability is properly configured in the client

![image](https://github.com/user-attachments/assets/e69c3e79-edfd-47d5-bed8-89fb798f448e)
