### PR TITLE
Downgrade Microsoft.VisualStudio.Language to 17.7.188

### DIFF
--- a/src/Cody.VisualStudio/Cody.VisualStudio.csproj
+++ b/src/Cody.VisualStudio/Cody.VisualStudio.csproj
@@ -125,7 +125,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Language">
-      <Version>17.11.260</Version>
+      <Version>17.7.188</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.0-previews-4-31709-430" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.6.2164">


### PR DESCRIPTION
Downgrade to enable support from version 17.8 of Visual Studio.

## Test plan
Run the extension on different versions of VS and see if an error window appears when trying to load the extension.
<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->
