### PR TITLE
Switched to Microsoft.VisualStudio.Language v17.6.268 - Autocomplete compatibility fix part 1

### DIFF
--- a/src/Cody.VisualStudio/Cody.VisualStudio.csproj
+++ b/src/Cody.VisualStudio/Cody.VisualStudio.csproj
@@ -125,10 +125,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Language">
-      <Version>17.11.260</Version>
+      <Version>17.6.268</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.0-previews-4-31709-430" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.6.2164">
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.0.1619-preview1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/Cody.VisualStudio/Cody.VisualStudio.csproj
+++ b/src/Cody.VisualStudio/Cody.VisualStudio.csproj
@@ -128,7 +128,7 @@
       <Version>17.6.268</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.0-previews-4-31709-430" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.0.1619-preview1">
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.6.2164">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Autocomplete compatibility fix allowing to support autocomplete starting from Visual Studio VS 17.6+
It was tested against VS versions:
 - 17.7.6
 - 17.9 Preview 2
 - 17.10.3
 - 17.12
 - 17.13.0 Preview 2.1

Internally `Microsoft.VisualStudio.Language` version is set to 17.0.0.0 after compilation, regardless of `Microsoft.VisualStudio.Language` version used as nuget package. The important part is `Microsoft.VisualStudio.Threading` library, which version set explicitly to match nuget `Microsoft.VisualStudio.Language` version.

![image](https://github.com/user-attachments/assets/046660c7-2269-4646-b326-fad5a7073efd)


## Test plan

1. Test autocomplete using your current VS version, and others if they are available.

