### PR TITLE
Document synch refactor

### DIFF
--- a/src/Cody.Core/Common/StringExtensions.cs
+++ b/src/Cody.Core/Common/StringExtensions.cs
@@ -11,8 +11,16 @@ namespace Cody.Core.Common
     {
         public static string ToUri(this string path)
         {
-            var uri = new Uri("file:///" + path).AbsoluteUri;
-            return Regex.Replace(uri, "(file:///)(\\D+)(:)", m => m.Groups[1].Value + m.Groups[2].Value.ToLower() + "%3A");
+            try
+            {
+                var uri = new Uri("file:///" + path).AbsoluteUri;
+                return Regex.Replace(uri, "(file:///)(\\D+)(:)", m => m.Groups[1].Value + m.Groups[2].Value.ToLower() + "%3A");
+            }
+            catch(Exception ex)
+            {
+                ex.Data.Add("path", path);
+                throw;
+            }
         }
 
         public static string ConvertLineBreaks(this string text, string lineBrakeChars)

--- a/src/Cody.VisualStudio/Services/DocumentsSyncService.cs
+++ b/src/Cody.VisualStudio/Services/DocumentsSyncService.cs
@@ -48,6 +48,7 @@ namespace Cody.VisualStudio.Services
                     frame.GetProperty((int)__VSFPROPID.VSFPROPID_DocCookie, out object cookie);
                     var docCookie = (uint)(int)cookie;
                     var path = rdt.GetDocumentInfo(docCookie).Moniker;
+                    if (path == null) continue;
                     var content = rdt.GetRunningDocumentContents(docCookie);
 
                     documentActions.OnOpened(path, content, null, null);
@@ -175,6 +176,7 @@ namespace Cody.VisualStudio.Services
             if (dwReadLocksRemaining == 0 && dwEditLocksRemaining == 0)
             {
                 var path = rdt.GetDocumentInfo(docCookie).Moniker;
+                if (path == null) return VSConstants.S_OK;
                 trace.TraceEvent("OnClosed", path);
                 documentActions.OnClosed(path);
 
@@ -187,6 +189,7 @@ namespace Cody.VisualStudio.Services
         int IVsRunningDocTableEvents.OnAfterSave(uint docCookie)
         {
             var path = rdt.GetDocumentInfo(docCookie).Moniker;
+            if (path == null) return VSConstants.S_OK;
             trace.TraceEvent("OnAfterSave", path);
             documentActions.OnSaved(path);
             return VSConstants.S_OK;
@@ -200,7 +203,7 @@ namespace Cody.VisualStudio.Services
             if (lastShowDocCookie != docCookie)
             {
                 var path = rdt.GetDocumentInfo(docCookie).Moniker;
-                trace.TraceEvent("OnDocumentFocus", path);           
+                if (path == null) return VSConstants.S_OK;
 
                 if (!isSubscribed.Contains(docCookie))
                 {
@@ -229,6 +232,7 @@ namespace Cody.VisualStudio.Services
                     }
                 }
 
+                trace.TraceEvent("OnDocumentFocus", path);
                 documentActions.OnFocus(path);
 
                 lastShowDocCookie = docCookie;
@@ -267,6 +271,7 @@ namespace Cody.VisualStudio.Services
                 var wpfTextView = textBuffer.Properties.GetProperty<IWpfTextView>(typeof(IWpfTextView));
 
                 var path = GetFilePath(wpfTextView);
+                if (path == null) return;
                 var selection = GetDocumentSelection(wpfTextView);
                 var changes = GetContentChanges(e.Changes, e.Before);
                 var visibleRange = GetVisibleRange(wpfTextView);
@@ -289,6 +294,7 @@ namespace Cody.VisualStudio.Services
                 var textView = ((ITextSelection)sender).TextView;
 
                 var path = GetFilePath(textView);
+                if(path == null) return;
                 var selection = GetDocumentSelection(textView);
                 var visibleRange = GetVisibleRange(textView);
 


### PR DESCRIPTION
- The previous version required the creation of all TextViews at the moment of opening the solution, which affected the loading performance of the solution. The new version uses lazy loading.
- Eliminating the active document object with references to the currently displayed document. This should eliminate problems with nulls when the object's state was being read and modified from different threads.
- Managing handlers to eliminate the possibility of losing certain events

## Test plan
Check for nulls in OnTextBufferChanged in the logs
<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->
