### PR TITLE
Extended logging for SentryLog

### DIFF
--- a/src/Cody.Core/Logging/ISentryLog.cs
+++ b/src/Cody.Core/Logging/ISentryLog.cs
@@ -1,11 +1,12 @@
 using System;
+using System.Runtime.CompilerServices;
 
 namespace Cody.Core.Logging
 {
     public interface ISentryLog
     {
-        void Error(Exception exception);
+        void Error(string message, Exception ex, [CallerMemberName] string callerName = "");
 
-        void Error(string message);
+        void Error(string message, [CallerMemberName] string callerName = "");
     }
 }

--- a/src/Cody.Core/Logging/Logger.cs
+++ b/src/Cody.Core/Logging/Logger.cs
@@ -65,7 +65,7 @@ namespace Cody.Core.Logging
             // TODO: _fileLogger.Error(customMessage);
             DebugWrite(customMessage);
             _outputWindowPane?.Error(message, callerName);
-            _sentryLog?.Error(customMessage);
+            _sentryLog?.Error(customMessage, callerName);
             _testLogger?.WriteLog(message, "ERROR", callerName);
         }
 
@@ -87,7 +87,7 @@ namespace Cody.Core.Logging
             // TODO: _fileLogger.Error(originalException, customMessage);
             DebugWrite(customMessage);
             _outputWindowPane?.Error(outputMessage, callerName);
-            _sentryLog?.Error(originalException);
+            _sentryLog?.Error(outputMessage, originalException, callerName);
             _testLogger?.WriteLog(message, "ERROR", callerName);
         }
 

--- a/src/Cody.Core/Logging/SentryLog.cs
+++ b/src/Cody.Core/Logging/SentryLog.cs
@@ -4,6 +4,7 @@ using System;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 
 namespace Cody.Core.Logging
 {
@@ -11,14 +12,21 @@ namespace Cody.Core.Logging
     {
         public const string CodyAssemblyPrefix = "Cody.";
 
-        public void Error(Exception exception)
+        public void Error(string message, Exception ex, [CallerMemberName] string callerName = "")
         {
-            SentrySdk.CaptureException(exception);
+            SentrySdk.CaptureException(ex, scope =>
+            {
+                scope.SetExtra(nameof(callerName), callerName);
+                scope.SetExtra(nameof(message), message);
+            });
         }
 
-        public void Error(string message)
+        public void Error(string message, [CallerMemberName] string callerName = "")
         {
-            SentrySdk.CaptureMessage(message);
+            SentrySdk.CaptureMessage(message, scope =>
+            {
+                scope.SetExtra(nameof(callerName), callerName);
+            });
         }
 
         public static void Initialize()


### PR DESCRIPTION
Support for message and caller method name parameters, internally exposed in the `Logger` class.

## Test plan

Create a test exception, and check if it's logged in the Sentry (`dev` environment).
