### PR TITLE
Added JSON context to configuration serialization error

### DIFF
--- a/src/Cody.Core/Infrastructure/ConfigurationService.cs
+++ b/src/Cody.Core/Infrastructure/ConfigurationService.cs
@@ -99,6 +99,7 @@ namespace Cody.Core.Infrastructure
             }
             catch (Exception ex)
             {
+                ex.Data.Add("json", customConfiguration);
                 _logger.Error("Deserializing custom configuration failed.", ex);
             }
 


### PR DESCRIPTION
Added JSON context to configuration serialization error

## Test plan

Create a invalid JSON configuration, and check if it's logged in the Sentry (dev environment).
