### PR TITLE
Custom settings validation

### DIFF
--- a/src/Cody.Core/Infrastructure/ConfigurationService.cs
+++ b/src/Cody.Core/Infrastructure/ConfigurationService.cs
@@ -99,6 +99,15 @@ namespace Cody.Core.Infrastructure
             }
             catch (Exception ex)
             {
+                try
+                {
+                    //try to repair invalid json
+                    var customConfigurationTrial = "{" + customConfiguration + "}";
+                    var config = JsonConvert.DeserializeObject<Dictionary<string, object>>(customConfigurationTrial);
+                    return config;
+                }
+                catch { }
+
                 ex.Data.Add("json", customConfiguration);
                 _logger.Error("Deserializing custom configuration failed.", ex);
             }

--- a/src/Cody.UI/Controls/Options/GeneralOptionsControl.xaml
+++ b/src/Cody.UI/Controls/Options/GeneralOptionsControl.xaml
@@ -10,6 +10,17 @@
              d:DesignHeight="300"
              >
     <Grid>
+        <Grid.Resources>
+            <Style x:Key="textBoxInError" TargetType="TextBox">
+                <Style.Triggers>
+                    <Trigger Property="Validation.HasError" Value="true">
+                        <Setter Property="ToolTip"
+              Value="{Binding RelativeSource={x:Static RelativeSource.Self},
+              Path=(Validation.Errors)[0].ErrorContent}"/>
+                    </Trigger>
+                </Style.Triggers>
+            </Style>
+        </Grid.Resources>
         <GroupBox Header="Cody">
             <Grid Margin="3,6,3,3">
                 <Grid.RowDefinitions>
@@ -31,7 +42,7 @@
                     Grid.Row="1"
                     Grid.Column="0"
                     >
-                    <Label Content="Cody Settings (JSON)" />
+                    <Label Content="Custom settings (JSON)" />
                     <Label Content="(requires restart)" HorizontalAlignment="Center"
                            Padding="0"
                            />
@@ -43,13 +54,18 @@
                     Grid.Column="1"
                     Width="400"
                     Height="100"
-                    Text="{Binding CustomConfiguration, Mode=TwoWay}"
+                    Style="{StaticResource textBoxInError}"
                     TextWrapping="Wrap"
                     AcceptsReturn="True"
                     AcceptsTab="True"
-                    ToolTip="Your Cody configuration JSON file."
+                    ToolTip="Cody configuration JSON."
                     Name="CustomConfigurationTextBox"
-                />
+                >
+                    <TextBox.Text>
+                        <Binding Path="CustomConfiguration" Mode="TwoWay" ValidatesOnDataErrors="True" UpdateSourceTrigger="PropertyChanged">
+                        </Binding>
+                    </TextBox.Text>
+                </TextBox>
 
                 <!--Accept non-trusted certificates -->
                 <CheckBox

--- a/src/Cody.UI/Controls/Options/GeneralOptionsControl.xaml
+++ b/src/Cody.UI/Controls/Options/GeneralOptionsControl.xaml
@@ -54,7 +54,6 @@
                     TextWrapping="Wrap"
                     AcceptsReturn="True"
                     AcceptsTab="True"
-                    ToolTip="Cody configuration JSON."
                     Name="CustomConfigurationTextBox"
                 >
                     <TextBox.Text>

--- a/src/Cody.UI/Controls/Options/GeneralOptionsControl.xaml
+++ b/src/Cody.UI/Controls/Options/GeneralOptionsControl.xaml
@@ -32,27 +32,23 @@
                 </Grid.RowDefinitions>
 
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="Auto" />
-                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="128" />
+                    <ColumnDefinition Width="*" />
                 </Grid.ColumnDefinitions>
 
 
                 <!--Custom Cody Configuration-->
-                <StackPanel
-                    Grid.Row="1"
-                    Grid.Column="0"
-                    >
-                    <Label Content="Custom settings (JSON)" />
-                    <Label Content="(requires restart)" HorizontalAlignment="Center"
-                           Padding="0"
-                           />
-                </StackPanel>
+                <Label Grid.Row="1" Grid.Column="0" HorizontalAlignment="Stretch">
+                    <TextBlock TextWrapping="Wrap">
+                        Custom JSON settings (requires restart)
+                    </TextBlock>
+                </Label>
 
                 <TextBox
                     Margin="0 2 0 5"
                     Grid.Row="1"
                     Grid.Column="1"
-                    Width="400"
+                    HorizontalAlignment="Stretch"
                     Height="100"
                     Style="{StaticResource textBoxInError}"
                     TextWrapping="Wrap"

--- a/src/Cody.UI/ViewModels/GeneralOptionsViewModel.cs
+++ b/src/Cody.UI/ViewModels/GeneralOptionsViewModel.cs
@@ -103,7 +103,7 @@ namespace Cody.UI.ViewModels
             {
                 if (columnName == nameof(CustomConfiguration))
                 {
-                    if (!IsCustomConfigurationValid()) return "Invalid custom settings. Make sure you enter the correct JSON.";
+                    if (!IsCustomConfigurationValid()) return "Invalid custom settings. Make sure you enter the correct JSON (including opening and closing brackets).";
                 }
 
                 return null;

--- a/src/Cody.UI/ViewModels/GeneralOptionsViewModel.cs
+++ b/src/Cody.UI/ViewModels/GeneralOptionsViewModel.cs
@@ -1,11 +1,15 @@
 using Cody.Core.Logging;
 using Cody.UI.MVVM;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using System;
+using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 
 namespace Cody.UI.ViewModels
 {
-    public class GeneralOptionsViewModel : NotifyPropertyChangedBase
+    public class GeneralOptionsViewModel : NotifyPropertyChangedBase, IDataErrorInfo
     {
         private readonly ILog _logger;
 
@@ -78,5 +82,32 @@ namespace Cody.UI.ViewModels
             }
         }
 
+        public bool IsCustomConfigurationValid()
+        {
+            try
+            {
+                JsonConvert.DeserializeObject<Dictionary<string, object>>(CustomConfiguration);
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        public string Error => null;
+
+        public string this[string columnName]
+        {
+            get
+            {
+                if (columnName == nameof(CustomConfiguration))
+                {
+                    if (!IsCustomConfigurationValid()) return "Invalid custom settings. Make sure you enter the correct JSON.";
+                }
+
+                return null;
+            }
+        }
     }
 }

--- a/src/Cody.VisualStudio/Options/GeneralOptionsPage.cs
+++ b/src/Cody.VisualStudio/Options/GeneralOptionsPage.cs
@@ -72,6 +72,14 @@ namespace Cody.VisualStudio.Options
         }
         protected override void OnApply(PageApplyEventArgs args)
         {
+            if (!_generalOptionsViewModel.IsCustomConfigurationValid())
+            {
+                var message = _generalOptionsViewModel[nameof(GeneralOptionsViewModel.CustomConfiguration)];
+                VsShellUtilities.ShowMessageBox(ServiceProvider.GlobalProvider, message, "Cody", OLEMSGICON.OLEMSGICON_WARNING, OLEMSGBUTTON.OLEMSGBUTTON_OK, OLEMSGDEFBUTTON.OLEMSGDEFBUTTON_FIRST);
+                args.ApplyBehavior = ApplyKind.CancelNoNavigate;
+                return;
+            }
+
             _logger.Debug($"{args.ApplyBehavior}");
 
             var customConfiguration = _generalOptionsViewModel.CustomConfiguration;
@@ -92,6 +100,11 @@ namespace Cody.VisualStudio.Options
 
         protected override void OnClosed(EventArgs e)
         {
+            if (!_generalOptionsViewModel.IsCustomConfigurationValid())
+            {
+                _generalOptionsViewModel.CustomConfiguration = string.Empty;
+            }
+
             _logger.Debug($"Settings page closed.");
 
             base.OnClosed(e);


### PR DESCRIPTION
- Adding validation to custom configuration in the options window
- Attempting to automatically repair an already existing json configuration
## Test plan

<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->
1. Open the options window
2. Select Cody settings
3. Try entering an invalid json in the custom settings field