### PR TITLE
Sentry time bomb

### DIFF
--- a/src/Cody.Core/Cody.Core.csproj
+++ b/src/Cody.Core/Cody.Core.csproj
@@ -130,9 +130,7 @@
     <PackageReference Include="Newtonsoft.Json">
       <Version>13.0.1</Version>
     </PackageReference>
-    <PackageReference Include="Sentry">
-      <Version>4.13.0</Version>
-    </PackageReference>
+    <PackageReference Include="Sentry" Version="4.13.0" />
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/Cody.Core/Logging/SentryLog.cs
+++ b/src/Cody.Core/Logging/SentryLog.cs
@@ -50,7 +50,9 @@ namespace Cody.Core.Logging
                 var buffer = new byte[2048];
 
                 using (var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read))
+                {
                     stream.Read(buffer, 0, buffer.Length);
+                }
 
                 var offset = BitConverter.ToInt32(buffer, PeHeaderOffset);
                 var secondsSince1970 = BitConverter.ToInt32(buffer, offset + LinkerTimestampOffset);
@@ -61,7 +63,7 @@ namespace Cody.Core.Logging
             }
             catch
             {
-                return DateTime.Now;
+                return DateTime.UtcNow;
             }
         }
 


### PR DESCRIPTION
Disable error logging to Sentry after 180 days from build date. The change is intended to limit the number of events sent. We are mainly interested in the latest versions of the extension so older versions should be out of the scope after six months.
## Test plan
Check if after 6 months the extension version logs any errors to Sentry 😉
<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->
