### PR TITLE
Added Debug.Assert to monitor when the agent disconnects.

### DIFF
--- a/src/Cody.VisualStudio/Client/AgentClient.cs
+++ b/src/Cody.VisualStudio/Client/AgentClient.cs
@@ -6,6 +6,7 @@ using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Serialization;
 using StreamJsonRpc;
 using System;
+using System.Diagnostics;
 using System.Threading.Tasks;
 
 namespace Cody.VisualStudio.Client
@@ -129,6 +130,8 @@ namespace Cody.VisualStudio.Client
 
                 Start();
             }
+
+            Debug.Assert(false, $"OnAgentDisconnected exitCode: {exitCode}");
         }
 
         public void Stop()


### PR DESCRIPTION
Added `Debug.Assert()` to ease monitoring when the agent disconnects. It will make easier to check if the agent successfully restarts, and will help investigating the root cause of disconnecting.

[Relevant logs](https://sourcegraph.sentry.io/issues/6123388490/?project=4508375896752129&query=is%3Aunresolved%20release.version%3A0.3.1.0&referrer=issue-stream&statsPeriod=2d&stream_index=0
)
## Test plan

N/A
