### PR TITLE
Added debug asserts in the Initialize() method.

### DIFF
--- a/src/Cody.VisualStudio/Services/DocumentsSyncService.cs
+++ b/src/Cody.VisualStudio/Services/DocumentsSyncService.cs
@@ -10,6 +10,7 @@ using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.TextManager.Interop;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 
@@ -52,6 +53,7 @@ namespace Cody.VisualStudio.Services
                 try
                 {
                     uint activeCookie = 0;
+                    AssertThatNoOpenedDocuments();
                     foreach (var frame in GetOpenDocuments())
                     {
                         if (frame.GetProperty((int)__VSFPROPID.VSFPROPID_DocCookie, out object cookie) != VSConstants.S_OK) continue;
@@ -81,6 +83,12 @@ namespace Cody.VisualStudio.Services
                     rdtCookie = rdt.Advise(this);
                 }
             });
+        }
+
+        private void AssertThatNoOpenedDocuments()
+        {
+            Debug.Assert(openNotificationSend.Count == 0, $"{nameof(openNotificationSend)} is {openNotificationSend}, but it should be ZERO!");
+            Debug.Assert(isSubscribed.Count == 0, $"{nameof(isSubscribed)} is {isSubscribed}, but it should be ZERO!");
         }
 
         private IVsTextView GetVsTextView(IVsWindowFrame windowFrame)


### PR DESCRIPTION
Added debug asserts in the Initialize() method will help to monitor breaking of internal contract - `openNotificationSend` and `isSubscribed` should be always empty when Initialize() is called.

## Test plan

In debug mode those asserts should be never called after opening a new solution.
