### PR TITLE
Fixes handling Home/Enter keys by the Cody Chat when editing prompt

### DIFF
--- a/src/Cody.UI/Cody.UI.csproj
+++ b/src/Cody.UI/Cody.UI.csproj
@@ -47,6 +47,7 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Controls\CodyWebView2.cs" />
     <Compile Include="Controls\Options\GeneralOptionsControl.xaml.cs">
       <DependentUpon>GeneralOptionsControl.xaml</DependentUpon>
     </Compile>

--- a/src/Cody.UI/Controls/CodyWebView2.cs
+++ b/src/Cody.UI/Controls/CodyWebView2.cs
@@ -1,0 +1,13 @@
+using Microsoft.Web.WebView2.Wpf;
+using System.Windows.Input;
+
+namespace Cody.UI.Controls
+{
+    public class CodyWebView2: WebView2
+    {
+        protected override void OnPreviewKeyDown(KeyEventArgs e)
+        {
+            // prevents WebView2 from handling custom key events (like Home/Enter keys not working in the Cody Chat during prompt editing)
+        }
+    }
+}

--- a/src/Cody.UI/Controls/WebView2Dev.xaml
+++ b/src/Cody.UI/Controls/WebView2Dev.xaml
@@ -17,7 +17,7 @@
             </Grid.RowDefinitions>
 
 
-            <wpf:WebView2 Name="webView" Grid.Row="1" Loaded="InitWebView2"
+            <local:CodyWebView2 x:Name="webView" Grid.Row="1" Loaded="InitWebView2"
               
             />
         </Grid>


### PR DESCRIPTION
CLOSE https://linear.app/sourcegraph/issue/CODY-4814/visual-studio-home-and-end-key-behavior
CLOSE https://linear.app/sourcegraph/issue/CODY-5463/fix-issue-with-end-key-functionality

This PR disables the custom key handling in WebView2 - `Home` and `End` weren't working properly when an user tried to navigate through text in the prompt.
 
## Test plan

1. Open Cody Tool Window
2. Write a prompt and navigate in the text by pressing Home and End keys
