### PR TITLE
Updated the authorization flow to use the "authStatus/didUpdate"

### DIFF
--- a/src/Cody.Core/Agent/INotificationHandler.cs
+++ b/src/Cody.Core/Agent/INotificationHandler.cs
@@ -1,8 +1,5 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Cody.Core.Agent.Protocol;
 
 namespace Cody.Core.Agent
 {
@@ -10,5 +7,6 @@ namespace Cody.Core.Agent
     {
         event EventHandler OnOptionsPageShowRequest;
         event EventHandler<string> OnRegisterWebViewRequest;
+        event EventHandler<ProtocolAuthStatus> AuthorizationDetailsChanged;
     }
 }

--- a/src/Cody.Core/Agent/NotificationHandlers.cs
+++ b/src/Cody.Core/Agent/NotificationHandlers.cs
@@ -27,6 +27,7 @@ namespace Cody.Core.Agent
 
         public event EventHandler<SetHtmlEvent> OnSetHtmlEvent;
 
+        public event EventHandler<ProtocolAuthStatus> AuthorizationDetailsChanged;
         public event EventHandler<string> OnRegisterWebViewRequest;
         public event EventHandler OnOptionsPageShowRequest;
         public event EventHandler OnFocusSidebarRequest;
@@ -222,6 +223,19 @@ namespace Cody.Core.Agent
         public void FocusSidebar(object param)
         {
             OnFocusSidebarRequest?.Invoke(this, EventArgs.Empty);
+        }
+
+        [AgentCallback("authStatus/didUpdate", deserializeToSingleObject: true)]
+        public void AuthStatusDidUpdate(ProtocolAuthStatus authStatus)
+        {
+            _logger.Debug($"Pending validation: {authStatus.PendingValidation}");
+
+            if (authStatus.PendingValidation)
+                return;
+
+            _logger.Debug($"Authenticated: {authStatus.Authenticated}");
+
+            AuthorizationDetailsChanged?.Invoke(this, authStatus);
         }
     }
 }

--- a/src/Cody.Core/Agent/Protocol/ProtocolAuthStatus.cs
+++ b/src/Cody.Core/Agent/Protocol/ProtocolAuthStatus.cs
@@ -11,17 +11,13 @@ namespace Cody.Core.Agent.Protocol
     [JsonConverter(typeof(ProtocolAuthStatusConverter))]
     public abstract class ProtocolAuthStatus
     {
-        [JsonProperty("status")]
         [JsonConverter(typeof(StringEnumConverter))]
         public StatusEnum Status { get; set; }
 
-        [JsonProperty("authenticated")]
         public bool Authenticated { get; set; }
 
-        [JsonProperty("endpoint")]
         public string Endpoint { get; set; }
 
-        [JsonProperty("pendingValidation")]
         public bool PendingValidation { get; set; }
 
         public enum StatusEnum
@@ -33,33 +29,25 @@ namespace Cody.Core.Agent.Protocol
 
     public class ProtocolAuthenticatedAuthStatus : ProtocolAuthStatus
     {
-        [JsonProperty("username")]
         public string Username { get; set; }
 
-        [JsonProperty("isFireworksTracingEnabled")]
         public bool? IsFireworksTracingEnabled { get; set; }
 
-        [JsonProperty("hasVerifiedEmail")]
         public bool? HasVerifiedEmail { get; set; }
 
-        [JsonProperty("requiresVerifiedEmail")]
         public bool? RequiresVerifiedEmail { get; set; }
 
-        [JsonProperty("primaryEmail")]
         public string PrimaryEmail { get; set; }
 
-        [JsonProperty("displayName")]
         public string DisplayName { get; set; }
 
-        [JsonProperty("avatarURL")]
         public string AvatarURL { get; set; }
 
-        [JsonProperty("organizations")] public List<OrganizationsParams> Organizations { get; set; }
+        public List<OrganizationsParams> Organizations { get; set; }
     }
 
     public class ProtocolUnauthenticatedAuthStatus : ProtocolAuthStatus
     {
-        [JsonProperty("error")]
         public AuthError Error { get; set; }
     }
 

--- a/src/Cody.Core/Agent/Protocol/ProtocolAuthStatus.cs
+++ b/src/Cody.Core/Agent/Protocol/ProtocolAuthStatus.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Linq;
+using System.Runtime.Serialization;
+
+
+namespace Cody.Core.Agent.Protocol
+{
+    [JsonConverter(typeof(ProtocolAuthStatusConverter))]
+    public abstract class ProtocolAuthStatus
+    {
+        [JsonProperty("status")]
+        [JsonConverter(typeof(StringEnumConverter))]
+        public StatusEnum Status { get; set; }
+
+        [JsonProperty("authenticated")]
+        public bool Authenticated { get; set; }
+
+        [JsonProperty("endpoint")]
+        public string Endpoint { get; set; }
+
+        [JsonProperty("pendingValidation")]
+        public bool PendingValidation { get; set; }
+
+        public enum StatusEnum
+        {
+            [EnumMember(Value = "authenticated")] Authenticated,
+            [EnumMember(Value = "unauthenticated")] Unauthenticated
+        }
+    }
+
+    public class ProtocolAuthenticatedAuthStatus : ProtocolAuthStatus
+    {
+        [JsonProperty("username")]
+        public string Username { get; set; }
+
+        [JsonProperty("isFireworksTracingEnabled")]
+        public bool? IsFireworksTracingEnabled { get; set; }
+
+        [JsonProperty("hasVerifiedEmail")]
+        public bool? HasVerifiedEmail { get; set; }
+
+        [JsonProperty("requiresVerifiedEmail")]
+        public bool? RequiresVerifiedEmail { get; set; }
+
+        [JsonProperty("primaryEmail")]
+        public string PrimaryEmail { get; set; }
+
+        [JsonProperty("displayName")]
+        public string DisplayName { get; set; }
+
+        [JsonProperty("avatarURL")]
+        public string AvatarURL { get; set; }
+
+        [JsonProperty("organizations")] public List<OrganizationsParams> Organizations { get; set; }
+    }
+
+    public class ProtocolUnauthenticatedAuthStatus : ProtocolAuthStatus
+    {
+        [JsonProperty("error")]
+        public AuthError Error { get; set; }
+    }
+
+    public class ProtocolAuthStatusConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(ProtocolAuthStatus);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue,
+            JsonSerializer serializer)
+        {
+            var jsonObject = JObject.Load(reader);
+
+            // Get the status discriminator
+            var status = jsonObject["status"]?.ToString();
+
+            // Create the appropriate concrete type based on the discriminator
+            ProtocolAuthStatus result;
+            if (status == "authenticated")
+                result = new ProtocolAuthenticatedAuthStatus();
+            else if (status == "unauthenticated")
+                result = new ProtocolUnauthenticatedAuthStatus();
+            else
+                throw new Exception($"Unknown discriminator {status}");
+
+            serializer.Populate(jsonObject.CreateReader(), result);
+
+            return result;
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            JObject.FromObject(value, serializer).WriteTo(writer);
+        }
+    }
+
+    public class OrganizationsParams
+    {
+        // not used
+    }
+
+    public class AuthError
+    {
+        // not used
+    }
+
+
+}

--- a/src/Cody.Core/Cody.Core.csproj
+++ b/src/Cody.Core/Cody.Core.csproj
@@ -59,6 +59,7 @@
     <Compile Include="Agent\Protocol\AutocompleteParams.cs" />
     <Compile Include="Agent\Protocol\AutocompleteResult.cs" />
     <Compile Include="Agent\Protocol\ChatPanelInfo.cs" />
+    <Compile Include="Agent\Protocol\ProtocolAuthStatus.cs" />
     <Compile Include="Agent\Protocol\CompletionBookkeepingEvent.cs" />
     <Compile Include="Agent\Protocol\CompletionItemInfo.cs" />
     <Compile Include="Agent\Protocol\CompletionItemParams.cs" />

--- a/src/Cody.Core/Infrastructure/ISecretStorageService.cs
+++ b/src/Cody.Core/Infrastructure/ISecretStorageService.cs
@@ -8,7 +8,5 @@ namespace Cody.Core.Infrastructure
         string Get(string key);
         void Delete(string key);
         string AccessToken { get; set; }
-
-        event EventHandler AuthorizationDetailsChanged;
     }
 }

--- a/src/Cody.Core/Infrastructure/WebViewsManager.cs
+++ b/src/Cody.Core/Infrastructure/WebViewsManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using Cody.Core.Agent;
@@ -138,7 +139,7 @@ namespace Cody.Core.Infrastructure
 
                 var nowTime = DateTime.Now;
                 var currentSpan = nowTime - startTime;
-                if (currentSpan >= _agentInitializationTimeout)
+                if (currentSpan >= _agentInitializationTimeout && !Debugger.IsAttached)
                 {
                     var message = $"Agent initialization timeout! Waiting for more than {currentSpan.TotalSeconds} s.";
                     _logger.Error(message);

--- a/src/Cody.VisualStudio/CodyPackage.cs
+++ b/src/Cody.VisualStudio/CodyPackage.cs
@@ -120,7 +120,6 @@ namespace Cody.VisualStudio
             var vsSecretStorage = this.GetService<SVsCredentialStorageService, IVsCredentialStorageService>();
             SecretStorageService = new SecretStorageService(vsSecretStorage, Logger);
             UserSettingsService = new UserSettingsService(new UserSettingsProvider(this), SecretStorageService, Logger);
-            SecretStorageService.AuthorizationDetailsChanged += AuthorizationDetailsChanged;
 
             ConfigurationService = new ConfigurationService(VersionService, VsVersionService, SolutionService, UserSettingsService, Logger);
 
@@ -134,6 +133,7 @@ namespace Cody.VisualStudio
             NotificationHandlers = new NotificationHandlers(UserSettingsService, AgentNotificationsLogger, FileService, SecretStorageService);
             NotificationHandlers.OnOptionsPageShowRequest += HandleOnOptionsPageShowRequest;
             NotificationHandlers.OnFocusSidebarRequest += HandleOnFocusSidebarRequest;
+            NotificationHandlers.AuthorizationDetailsChanged += AuthorizationDetailsChanged;
 
 
             ProgressNotificationHandlers = new ProgressNotificationHandlers(ProgressService);
@@ -200,7 +200,7 @@ namespace Cody.VisualStudio
             }
         }
 
-        private async void AuthorizationDetailsChanged(object sender, EventArgs eventArgs)
+        private async void AuthorizationDetailsChanged(object sender, ProtocolAuthStatus status)
         {
             try
             {
@@ -210,9 +210,6 @@ namespace Cody.VisualStudio
                     Logger.Debug("Not changed.");
                     return;
                 }
-
-                var config = ConfigurationService.GetConfiguration();
-                var status = await AgentService.ConfigurationChange(config);
 
                 UpdateCurrentWorkspaceFolder();
 

--- a/src/Cody.VisualStudio/Services/SecretStorageService.cs
+++ b/src/Cody.VisualStudio/Services/SecretStorageService.cs
@@ -14,8 +14,6 @@ namespace Cody.VisualStudio.Services
         private readonly string UserName = "CodyAgent";
         private readonly string Type = "token";
 
-        public event EventHandler AuthorizationDetailsChanged;
-
         public SecretStorageService(IVsCredentialStorageService secretStorageService, ILog logger)
         {
             _secretStorageService = secretStorageService;
@@ -32,9 +30,6 @@ namespace Cody.VisualStudio.Services
                 var value = credential?.TokenValue;
                 //_logger.Debug($"Get '{key}':{value}");
 
-                if (IsEndpoint(key))
-                    AuthorizationDetailsChanged?.Invoke(this, EventArgs.Empty);
-
                 return value;
             }
             catch (Exception ex)
@@ -44,29 +39,6 @@ namespace Cody.VisualStudio.Services
 
             return null;
 
-        }
-
-        private bool IsEndpoint(string key)
-        {
-            try
-            {
-                var isUri = IsValidUri(key);
-                if (isUri)
-                {
-                    _logger.Debug($"Detected Uri:'{key}'");
-                    return true;
-                }
-            }
-            catch (Exception ex)
-            {
-                _logger.Error("Failed.", ex);
-            }
-
-            return false;
-        }
-        private bool IsValidUri(string uriString)
-        {
-            return Uri.TryCreate(uriString, UriKind.Absolute, out _);
         }
 
         public void Set(string key, string value)
@@ -115,9 +87,6 @@ namespace Cody.VisualStudio.Services
             {
                 var oldAccessToken = AccessToken;
                 Set(AccessTokenKey, value);
-
-                if (oldAccessToken != value)
-                    AuthorizationDetailsChanged?.Invoke(this, EventArgs.Empty);
             }
         }
     }


### PR DESCRIPTION
 Updated the authorization flow to use the "authStatus/didUpdate" notification from the agent:
  - Removed the heuristic for detecting log in/log out from SecretStorageService.
  - Added support for the "authStatus/didUpdate" flow in NotificationHandlers.
  - Added serialization support for the agent's ProtocolAuthStatus discriminated union type using ProtocolAuthStatusConverter.

Added support to wait for the chat to be fully loaded during debugging when a debugger is attached (no more timeouts).

## Test plan

1. Cody log out state
 - Log in to Cody, look for `Pending validation: true/false` and `Authenticated: true` in the `Cody Notifications` output
 - Successful login

2. Cody log in state
 - Log out from Cody, look for `Pending validation: false` and `Authenticated: false`  output
 - Successful logout

