### PR TITLE
Prevent webview to overlap other controls

### DIFF
--- a/src/Cody.UI/Cody.UI.csproj
+++ b/src/Cody.UI/Cody.UI.csproj
@@ -88,7 +88,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.0-previews-4-31709-430" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Web.WebView2">
-      <Version>1.0.2592.51</Version>
+      <Version>1.0.3296.44</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup />

--- a/src/Cody.UI/Controls/CodyWebView2.cs
+++ b/src/Cody.UI/Controls/CodyWebView2.cs
@@ -3,7 +3,7 @@ using System.Windows.Input;
 
 namespace Cody.UI.Controls
 {
-    public class CodyWebView2: WebView2
+    public class CodyWebView2 : WebView2CompositionControl
     {
         protected override void OnPreviewKeyDown(KeyEventArgs e)
         {

--- a/src/Cody.UI/Controls/WebviewController.cs
+++ b/src/Cody.UI/Controls/WebviewController.cs
@@ -33,6 +33,7 @@ namespace Cody.UI.Controls
             await ApplyVsCodeApiScript();
             SetupEventHandlers();
             ConfigureWebView();
+            SetupResourceHandling();
 
             return webView;
         }
@@ -58,10 +59,39 @@ namespace Cody.UI.Controls
             _webview.WebMessageReceived += HandleWebViewMessage;
         }
 
+        private void SetupResourceHandling()
+        {
+            string AppOrigin = "https://cody.vs";
+            _webview.AddWebResourceRequestedFilter($"{AppOrigin}*", CoreWebView2WebResourceContext.All);
+            _webview.WebResourceRequested += HandleWebResourceRequest;
+        }
+
+        private void HandleWebResourceRequest(object sender, CoreWebView2WebResourceRequestedEventArgs e)
+        {
+            var agentDir = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "Agent");
+            var uri = new Uri(e.Request.Uri);
+            var filePath = Path.Combine(agentDir, uri.AbsolutePath.TrimStart('/')).Replace("\\", "/");
+
+            if (System.IO.File.Exists(filePath))
+            {
+                var response = System.IO.File.ReadAllBytes(filePath);
+                var contentType = GetContentType(filePath);
+                e.Response = _webview.Environment.CreateWebResourceResponse(
+                    new MemoryStream(response), 200, "OK", contentType);
+            }
+        }
+
         private void SetupVirtualHostMapping()
         {
             string agentDir = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "Agent", "webviews");
             _webview.SetVirtualHostNameToFolderMapping("cody.vs", agentDir, CoreWebView2HostResourceAccessKind.Allow);
+        }
+
+        private string GetContentType(string filePath)
+        {
+            if (filePath.EndsWith(".js")) return "Content-Type: text/javascript";
+            if (filePath.EndsWith(".css")) return "Content-Type: text/css";
+            return "Content-Type: text/html";
         }
 
         private async void CoreWebView2OnDOMContentLoaded(object sender, CoreWebView2DOMContentLoadedEventArgs e)


### PR DESCRIPTION
The chat uses WebView2, which has always painted itself as the top window enclosing everything underneath. This was a known issue that, after years, was finally resolved by Microsoft (https://github.com/MicrosoftEdge/WebView2Feedback/issues/286). This PR changes WebView2 controls to the latest version that respects z-order in WPF.
## Test plan
Try opening another window above the chat window or docking it to the side of the ide and expanding it over the chat. In either case, the window above the chat should not be overlapped by the chat.
<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->
