### PR TITLE
Update agent and turn on CopyOnlyAction capability

### DIFF
--- a/agent/agent.version
+++ b/agent/agent.version
@@ -1,1 +1,1 @@
-vscode-v1.98.0
+vscode-insiders-v1.105.1750295617

--- a/src/Cody.Core/Agent/Protocol/ClientCapabilities.cs
+++ b/src/Cody.Core/Agent/Protocol/ClientCapabilities.cs
@@ -22,6 +22,7 @@ namespace Cody.Core.Agent.Protocol
         public Capability? Ignore { get; set; }
         public Capability? CodeActions { get; set; }
         public Capability? AccountSwitchingInWebview { get; set; }
+        public Capability? CodeCopyOnlyAction { get; set; }
 
         public Capability? Shell { get; set; }
         public WebviewMessagesCapability? WebviewMessages { get; set; }

--- a/src/Cody.Core/Infrastructure/ConfigurationService.cs
+++ b/src/Cody.Core/Infrastructure/ConfigurationService.cs
@@ -44,6 +44,7 @@ namespace Cody.Core.Infrastructure
                     Autoedit = Capability.Enabled,
                     AutoeditInlineDiff = AutoeditInlineDiffCapability.None,
                     AutoeditAsideDiff = AutoeditAsideDiffCapability.Diff,
+                    CodeCopyOnlyAction = Capability.Enabled,
                     Edit = Capability.None,
                     EditWorkspace = Capability.None,
                     ProgressBars = Capability.Enabled,


### PR DESCRIPTION
Turn on CopyOnlyAction capability to hide SmartApply button with is not supported.
## Test plan
N/A
<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->
