### PR TITLE
Open Explore Prompt Library in system browser

### DIFF
--- a/src/Cody.UI/Controls/WebviewController.cs
+++ b/src/Cody.UI/Controls/WebviewController.cs
@@ -1,5 +1,6 @@
 using Cody.Core.Common;
 using Cody.Core.Logging;
+using Microsoft.VisualStudio.Shell;
 using Microsoft.Web.WebView2.Core;
 using System;
 using System.IO;
@@ -56,6 +57,13 @@ namespace Cody.UI.Controls
         {
             _webview.DOMContentLoaded += CoreWebView2OnDOMContentLoaded;
             _webview.WebMessageReceived += HandleWebViewMessage;
+            _webview.NewWindowRequested += OnNewWindowRequested;
+        }
+
+        private void OnNewWindowRequested(object sender, CoreWebView2NewWindowRequestedEventArgs e)
+        {
+            VsShellUtilities.OpenSystemBrowser(e.Uri);
+            e.Handled = true;
         }
 
         private void SetupVirtualHostMapping()


### PR DESCRIPTION
CLOSE https://linear.app/sourcegraph/issue/QA-723/visual-studio-user-is-navigated-to-in-app-browser-instead-of-browser
User is navigated to In-App Browser instead of Browser after clicking Explore Prompt Library

## Test plan
Try to open Explore Prompt Library from Prompts menu. The page should open in the system browser.
<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->
