### PR TITLE
Additional logging for autoedit

### DIFF
--- a/src/Cody.UI/Controls/Options/GeneralOptionsControl.xaml
+++ b/src/Cody.UI/Controls/Options/GeneralOptionsControl.xaml
@@ -5,6 +5,8 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:Cody.UI.Controls.Options"
              xmlns:controls="clr-namespace:Cody.UI.Controls"
+             xmlns:imaging="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.Imaging"
+             xmlns:catalog="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.ImageCatalog"
              mc:Ignorable="d" 
              d:DesignWidth="500"
              d:DesignHeight="300"
@@ -73,14 +75,24 @@
                     Content="Accept non-trusted certificates (requires restart)"
                  />
 
-                <CheckBox
-                    Name="AutomaticallyTriggerCompletionsCheckBox"
+                <StackPanel
+                    Orientation="Horizontal"
                     Grid.Row="3"
                     Grid.Column="1"
-                    Margin="0 5 0 0"
-                    IsChecked="{Binding AutomaticallyTriggerCompletions, Mode=TwoWay}"
-                    Content="Automatically trigger completions"
-                 />
+                    Margin="0 5 0 0">
+                    <CheckBox
+                        Name="AutomaticallyTriggerCompletionsCheckBox"
+                        IsChecked="{Binding AutomaticallyTriggerCompletions, Mode=TwoWay}"
+                        Content="Automatically trigger completions"
+                     />
+                    <imaging:CrispImage
+                        Width="16"
+                        Height="16"
+                        Margin="4 0 0 0"
+                        Moniker="{x:Static catalog:KnownMonikers.InfoTipInline}"
+                        ToolTip="To use Cody autocomplete make sure that the “Show inline completions” option in the IntelliCode section is enabled." />
+                </StackPanel>
+                
 
                 <CheckBox
                     Name="EnableAutoEditCheckBox"
@@ -102,9 +114,6 @@
                     HorizontalAlignment="Left"
                     Command="{Binding ActivateBetaCommand}"
                 />
-
-
-
 
             </Grid>
         </GroupBox>

--- a/src/Cody.VisualStudio.Completions/Completions/CodyProposalSource.cs
+++ b/src/Cody.VisualStudio.Completions/Completions/CodyProposalSource.cs
@@ -4,14 +4,12 @@ using Cody.Core.Common;
 using Cody.Core.Settings;
 using Cody.Core.Trace;
 using Microsoft.VisualStudio.Language.Proposals;
-using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Differencing;
 using Microsoft.VisualStudio.Text.Editor;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -68,11 +66,15 @@ namespace Cody.VisualStudio.Completions
                 trace.TraceEvent("Begin", "session: {0}", session);
                 trace.TraceEvent("Scenario", "session: {0}, scenario {1}", session, scenario);
 
+                if (scenario == ProposalScenario.ExplicitInvocation)
+                    CodyPackage.Logger?.Info("Autocomplete explicitly triggered");
+
                 agentService = CodyPackage.AgentService;
                 userSettingsService = CodyPackage.UserSettingsService;
 
                 if (!ShouldDoProposals(completionState, scenario, agentService, userSettingsService))
                 {
+                    CodyPackage.Logger?.Info("Autocomplete omitted (is autocomplete enabled in settings window?)");
                     return null;
                 }
 
@@ -120,11 +122,17 @@ namespace Cody.VisualStudio.Completions
                 if (autocomplete == null)
                 {
                     trace.TraceEvent("Result", "session: {0}, No results (null)", session);
+                    if (scenario == ProposalScenario.ExplicitInvocation)
+                        CodyPackage.Logger?.Info("Autocomplete returned no suggestions");
+
                     return null;
                 }
                 else if (autocomplete.InlineCompletionItems.Length == 0 && autocomplete.DecoratedEditItems.Length == 0)
                 {
                     trace.TraceEvent("Result", "session: {0}, No results (empty)", session);
+                    if (scenario == ProposalScenario.ExplicitInvocation)
+                        CodyPackage.Logger?.Info("Autocomplete returned zero suggestions");
+
                     return null;
                 }
                 else
@@ -145,13 +153,24 @@ namespace Cody.VisualStudio.Completions
 
                 CodyProposalCollection collection = null;
                 if (autocomplete.DecoratedEditItems.Any())
+                {
                     collection = CreateAutoeditProposals(autocomplete, caret, completionState, session);
+                    if (scenario == ProposalScenario.ExplicitInvocation && collection != null)
+                        CodyPackage.Logger?.Info($"Number of auto-edits: {collection.Proposals.Count}");
+                }
                 else if (autocomplete.InlineCompletionItems.Any())
+                {
                     collection = CreateAutocompleteProposals(autocomplete, caret, completionState, session);
+                    if (scenario == ProposalScenario.ExplicitInvocation && collection != null)
+                        CodyPackage.Logger?.Info($"Number of autocompletes: {collection.Proposals.Count}");
+                }
 
                 if (collection == null || collection.Proposals.Count == 0)
                 {
                     trace.TraceEvent("NoProposalsToDisplay", "session: {0}", session);
+                    if (scenario == ProposalScenario.ExplicitInvocation)
+                        CodyPackage.Logger?.Info("No suggestions to display");
+
                     return null;
                 }
 
@@ -166,6 +185,7 @@ namespace Cody.VisualStudio.Completions
             catch (Exception ex)
             {
                 trace.TraceException(ex);
+                CodyPackage.Logger?.Error("Autocomplete error", ex);
             }
             finally
             {

--- a/src/Cody.VisualStudio.Tests/CodyPackageTests.cs
+++ b/src/Cody.VisualStudio.Tests/CodyPackageTests.cs
@@ -25,10 +25,10 @@ namespace Cody.VisualStudio.Tests
         public async Task Logger_Initialized_And_Info_MethodCalled()
         {
             // given
-            var codyPackage = await GetPackageAsync();
+            var logger = CodyPackage.Logger;
 
             // when
-            var logger = codyPackage.Logger;
+
             Assert.NotNull(logger);
 
             logger.Info("Hello World from integration tests!");

--- a/src/Cody.VisualStudio.Tests/TestsBase.cs
+++ b/src/Cody.VisualStudio.Tests/TestsBase.cs
@@ -1,19 +1,19 @@
+using Cody.Core.Logging;
+using EnvDTE80;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Events;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.TextManager.Interop;
 using System;
+using System.Diagnostics;
 using System.Drawing.Imaging;
 using System.IO;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using System.Windows;
-using Cody.Core.Logging;
-using EnvDTE80;
-using Microsoft.VisualStudio.Shell;
-using Microsoft.VisualStudio.Shell.Interop;
-using Microsoft.VisualStudio.TextManager.Interop;
 using Xunit.Abstractions;
-using System.Diagnostics;
 using Thread = System.Threading.Thread;
-using Microsoft.VisualStudio.Shell.Events;
 
 namespace Cody.VisualStudio.Tests
 {
@@ -27,7 +27,7 @@ namespace Cody.VisualStudio.Tests
         {
             _logger = output;
 
-            var logger = (Logger)CodyPackage?.Logger;
+            var logger = (Logger)CodyPackage.Logger;
             if (logger != null)
                 logger.WithTestLogger(this);
 

--- a/src/Cody.VisualStudio/CodyPackage.cs
+++ b/src/Cody.VisualStudio/CodyPackage.cs
@@ -51,7 +51,7 @@ namespace Cody.VisualStudio
 
         public const string PackageGuidString = "9b8925e1-803e-43d9-8f43-c4a4f35b4325";
 
-        public ILog Logger;
+        public static ILog Logger;
         public ILog AgentLogger;
         public ILog AgentNotificationsLogger;
 

--- a/src/Cody.VisualStudio/CodyToolWindow.cs
+++ b/src/Cody.VisualStudio/CodyToolWindow.cs
@@ -1,10 +1,10 @@
-using Microsoft.VisualStudio.Shell;
-using System;
-using System.Runtime.InteropServices;
 using Cody.UI.ViewModels;
 using Cody.UI.Views;
 using Cody.VisualStudio.Inf;
+using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
+using System;
+using System.Runtime.InteropServices;
 
 #pragma warning disable VSTHRD010
 
@@ -36,7 +36,7 @@ namespace Cody.VisualStudio
             // the object returned by the Content property.
 
             var package = GetPackage();
-            var logger = package.Logger;
+            var logger = CodyPackage.Logger;
             var notificationsHandlers = package.NotificationHandlers;
             var webViewsManager = package.WebViewsManager;
 

--- a/src/Cody.VisualStudio/Options/GeneralOptionsPage.cs
+++ b/src/Cody.VisualStudio/Options/GeneralOptionsPage.cs
@@ -26,7 +26,7 @@ namespace Cody.VisualStudio.Options
             _codyPackage = GetPackage();
             if (_codyPackage != null)
             {
-                _logger = _codyPackage.Logger;
+                _logger = CodyPackage.Logger;
                 _settingsService = CodyPackage.UserSettingsService;
 
                 _logger.Debug("Initialized.");


### PR DESCRIPTION
Extra logging visible in the Output window. This could be useful in case user complains about the lack of autocomplete/autoedit. The logging writes each step of the suggestion creation process. To see logs in Output window, force autocomplete using the `Alt + .` shortcut.
In addition, I added a tooltip in Cody's options window that informs user to enable the global option 'Show inline completions' if he/she wants to use autocomplete.
## Test plan
N/A
<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->
