### PR TITLE
Added logging for autocomplete v2

### DIFF
--- a/src/Cody.VisualStudio.Completions/Completions/CodyProposalManager.cs
+++ b/src/Cody.VisualStudio.Completions/Completions/CodyProposalManager.cs
@@ -30,15 +30,22 @@ namespace Cody.VisualStudio.Completions
 
         public override bool TryGetIsProposalPosition(VirtualSnapshotPoint caret, ProposalScenario scenario, char triggerCharacter, ref bool value)
         {
-            if (acceptedScenarios.Contains(scenario)) value = true;
-            else if (scenario == ProposalScenario.CaretMove)
+            try
             {
-                var currentLine = caret.Position.GetContainingLine();
-                if (currentLine.End != caret.Position) value = true;
-            }
+                if (acceptedScenarios.Contains(scenario)) value = true;
+                else if (scenario == ProposalScenario.CaretMove)
+                {
+                    var currentLine = caret.Position.GetContainingLine();
+                    if (currentLine.End != caret.Position) value = true;
+                }
 
-            trace.TraceEvent("ProposalScenario", scenario.ToString());
-            trace.TraceEvent("ShowProposal", value);
+                trace.TraceEvent("ProposalScenario", scenario.ToString());
+                trace.TraceEvent("ShowProposal", value);
+            }
+            catch (Exception ex)
+            {
+                _logger.Error("Failed.", ex);
+            }
 
             return value;
         }

--- a/src/Cody.VisualStudio.Completions/Completions/CodyProposalManagerProvider.cs
+++ b/src/Cody.VisualStudio.Completions/Completions/CodyProposalManagerProvider.cs
@@ -24,7 +24,7 @@ namespace Cody.VisualStudio.Completions
         [ImportingConstructor]
         public CodyProposalManagerProvider(LoggerFactory loggerFactory)
         {
-            _logger = loggerFactory.Create("Cody Completions");
+            _logger = loggerFactory.Create();
         }
 
         public async override Task<ProposalManagerBase> GetProposalManagerAsync(ITextView view, CancellationToken cancel)

--- a/src/Cody.VisualStudio.Completions/LoggerFactory.cs
+++ b/src/Cody.VisualStudio.Completions/LoggerFactory.cs
@@ -17,7 +17,7 @@ namespace Cody.VisualStudio.Completions
             
         }
 
-        public ILog Create(string outputName = null)
+        public ILog Create(string outputName = "Cody Completions")
         {
 
             Logger logger = null;

--- a/src/Cody.VisualStudio.Completions/LoggerFactory.cs
+++ b/src/Cody.VisualStudio.Completions/LoggerFactory.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using Cody.Core.Logging;
 using Cody.VisualStudio.Inf;
@@ -10,16 +12,19 @@ namespace Cody.VisualStudio.Completions
     [Export]
     public class LoggerFactory
     {
-
+        private static readonly ConcurrentDictionary<string, ILog> _loggers = new ConcurrentDictionary<string, ILog>();
 
         public LoggerFactory()
         {
-            
         }
 
         public ILog Create(string outputName = "Cody Completions")
         {
+            return _loggers.GetOrAdd(outputName, CreateLogger);
+        }
 
+        private ILog CreateLogger(string outputName = "Cody Completions")
+        {
             Logger logger = null;
             SentryLog sentryLog = null;
             try


### PR DESCRIPTION
Ported from #293 with updated logging architecture for Cody.VisualStudio.Completions

Original description:

Extra logging visible in the Output window. This could be useful in case user complains about the lack of autocomplete/autoedit. The logging writes each step of the suggestion creation process. To see logs in Output window, force autocomplete using the `Alt + .` shortcut.

## Test plan

Trigger auto-edits via `Alt + .` and observe "Cody Completions" output window.
