### PR TITLE
Tooltip describing how to get autocomplete turned on

### DIFF
--- a/src/Cody.UI/Controls/Options/GeneralOptionsControl.xaml
+++ b/src/Cody.UI/Controls/Options/GeneralOptionsControl.xaml
@@ -5,6 +5,8 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:Cody.UI.Controls.Options"
              xmlns:controls="clr-namespace:Cody.UI.Controls"
+             xmlns:imaging="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.Imaging"
+             xmlns:catalog="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.ImageCatalog"
              mc:Ignorable="d" 
              d:DesignWidth="500"
              d:DesignHeight="300"
@@ -73,14 +75,24 @@
                     Content="Accept non-trusted certificates (requires restart)"
                  />
 
-                <CheckBox
-                    Name="AutomaticallyTriggerCompletionsCheckBox"
+                <StackPanel
+                    Orientation="Horizontal"
                     Grid.Row="3"
                     Grid.Column="1"
-                    Margin="0 5 0 0"
-                    IsChecked="{Binding AutomaticallyTriggerCompletions, Mode=TwoWay}"
-                    Content="Automatically trigger completions"
-                 />
+                    Margin="0 5 0 0">
+                    <CheckBox
+                        Name="AutomaticallyTriggerCompletionsCheckBox"
+                        IsChecked="{Binding AutomaticallyTriggerCompletions, Mode=TwoWay}"
+                        Content="Automatically trigger completions"
+                     />
+                    <imaging:CrispImage
+                        Width="16"
+                        Height="16"
+                        Margin="4 0 0 0"
+                        Moniker="{x:Static catalog:KnownMonikers.InfoTipInline}"
+                        ToolTip="To use Cody autocomplete make sure that the “Show inline completions” option in the IntelliCode section is enabled." />
+                </StackPanel>
+
 
                 <CheckBox
                     Name="EnableAutoEditCheckBox"


### PR DESCRIPTION
Ported from #293 

Original description:

In addition, I added a tooltip in Cody's options window that informs user to enable the global option 'Show inline completions' if he/she wants to use autocomplete.

![image](https://github.com/user-attachments/assets/6a7ecbb2-fd34-480a-8997-152fc350d52e)


## Test plan

N/A
