### PR TITLE
UI visual indicators for the settings page when VS version is lower than 17.6 

### DIFF
--- a/src/Cody.Core/Ide/IVsVersionService.cs
+++ b/src/Cody.Core/Ide/IVsVersionService.cs
@@ -3,10 +3,9 @@ namespace Cody.Core.Ide
     public interface IVsVersionService
     {
         string SemanticVersion { get; }
-
         string DisplayVersion { get; }
-
         string EditionName { get; }
+        bool HasCompletionSupport { get; }
     }
 }
 

--- a/src/Cody.UI/Controls/Options/GeneralOptionsControl.xaml
+++ b/src/Cody.UI/Controls/Options/GeneralOptionsControl.xaml
@@ -7,6 +7,7 @@
              xmlns:controls="clr-namespace:Cody.UI.Controls"
              xmlns:imaging="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.Imaging"
              xmlns:catalog="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.ImageCatalog"
+             xmlns:converters="clr-namespace:Cody.UI.Converters"
              mc:Ignorable="d" 
              d:DesignWidth="500"
              d:DesignHeight="300"
@@ -79,18 +80,32 @@
                     Orientation="Horizontal"
                     Grid.Row="3"
                     Grid.Column="1"
-                    Margin="0 5 0 0">
+                    Margin="0 5 0 0"
+                    >
                     <CheckBox
                         Name="AutomaticallyTriggerCompletionsCheckBox"
                         IsChecked="{Binding AutomaticallyTriggerCompletions, Mode=TwoWay}"
                         Content="Automatically trigger completions"
+                        IsEnabled="{Binding HasCompletionSupport }"
                      />
+                    <!--Supported-->
                     <imaging:CrispImage
                         Width="16"
                         Height="16"
                         Margin="4 0 0 0"
                         Moniker="{x:Static catalog:KnownMonikers.InfoTipInline}"
-                        ToolTip="To use Cody autocomplete make sure that the “Show inline completions” option in the IntelliCode section is enabled." />
+                        ToolTip="To use Cody autocomplete make sure that the “Show inline completions” option in the IntelliCode section is enabled."
+                        Visibility="{Binding HasCompletionSupport , Converter={x:Static converters:BooleanToVisibilityConverter.Default}}"
+                        />
+                    <!--Not supported-->
+                    <imaging:CrispImage
+                        Width="16"
+                        Height="16"
+                        Margin="4 0 0 0"
+                        Moniker="{x:Static catalog:KnownMonikers.StatusInvalid}"
+                        ToolTip="Visual Studio 17.6+ is required to use Cody autocomplete or auto-edit. "
+                        Visibility="{Binding HasCompletionSupport , Converter={x:Static converters:BooleanToVisibilityConverter.Inverted}}"
+                    />
                 </StackPanel>
 
 
@@ -100,8 +115,9 @@
                     Grid.Column="1"
                     Margin="0 5 0 0"
                     IsChecked="{Binding EnableAutoEdit, Mode=TwoWay}"
-                    Content="Enable Cody Auto-edit (requires restart)"
- />
+                    Content="Enable Cody auto-edit (requires restart)"
+                    IsEnabled="{Binding HasCompletionSupport}"
+                   />
 
                 <!--Get Help-->
                 <Button 

--- a/src/Cody.VisualStudio/Options/GeneralOptionsPage.cs
+++ b/src/Cody.VisualStudio/Options/GeneralOptionsPage.cs
@@ -133,7 +133,7 @@ namespace Cody.VisualStudio.Options
                     _logger.Debug("Creating options control ...");
 
                     _control = new GeneralOptionsControl();
-                    _generalOptionsViewModel = new GeneralOptionsViewModel(_logger);
+                    _generalOptionsViewModel = new GeneralOptionsViewModel(_codyPackage.VsVersionService, _logger);
                     _control.DataContext = _generalOptionsViewModel;
 
                     _codyPackage.GeneralOptionsViewModel = _generalOptionsViewModel;

--- a/src/Cody.VisualStudio/Services/VsVersionService.cs
+++ b/src/Cody.VisualStudio/Services/VsVersionService.cs
@@ -15,9 +15,18 @@ namespace Cody.VisualStudio.Services
         {
             _logger = logger;
 
-            SemanticVersion = GetAppIdStringProperty(VSAPropID.ProductSemanticVersion);
-            DisplayVersion = GetAppIdStringProperty(VSAPropID.ProductDisplayVersion);
-            EditionName = GetAppIdStringProperty(VSAPropID.EditionName);
+            try
+            {
+                SemanticVersion = GetAppIdStringProperty(VSAPropID.ProductSemanticVersion);
+                DisplayVersion = GetAppIdStringProperty(VSAPropID.ProductDisplayVersion);
+                EditionName = GetAppIdStringProperty(VSAPropID.EditionName);
+
+                Version = Version.Parse(DisplayVersion);
+            }
+            catch (Exception ex)
+            {
+                _logger.Error("Retrieving VS version failed.", ex);
+            }
         }
 
 
@@ -27,6 +36,19 @@ namespace Cody.VisualStudio.Services
 
         public string EditionName { get; }
 
+        public Version Version { get; }
+
+        public bool HasCompletionSupport
+        {
+            get
+            {
+                var minimalVersion = new Version(17, 6);
+
+                if (Version >= minimalVersion)
+                    return true;
+                return false;
+            }
+        }
 
         [Guid("1EAA526A-0898-11d3-B868-00C04F79F802")]
         [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]


### PR DESCRIPTION
This PR implements version checking to ensure Cody's completion and auto-edit features are only available on supported Visual Studio versions (17.6+).

## Test plan

1. If VS version < 17.6 the settings page should look like this:

![image](https://github.com/user-attachments/assets/47d8b2cd-c94e-4cca-a39e-cc15caf743b8)

2. For VS version 17.6 and later the settings page should look like this:

![image](https://github.com/user-attachments/assets/89e5bb02-d1f4-4a33-8f95-dac301108641)

