### PR TITLE
Fix CodyDevConfig.json parsing for RemoteAgentPort/TraceLogioPort

### DIFF
--- a/src/Cody.Core.Tests/Cody.Core.Tests.csproj
+++ b/src/Cody.Core.Tests/Cody.Core.Tests.csproj
@@ -45,6 +45,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ConfiguartionFileJsonTests.cs" />
     <Compile Include="CustomConfigurationTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="StringExtensionsTests.cs" />

--- a/src/Cody.Core.Tests/ConfiguartionFileJsonTests.cs
+++ b/src/Cody.Core.Tests/ConfiguartionFileJsonTests.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Cody.Core.Common;
+using Cody.Core.Logging;
+using Moq;
+using NUnit.Framework;
+
+namespace Cody.Core.Tests
+{
+    public class ConfiguartionFileJsonTests
+    {
+        private Mock<ILog> _loggerMock;
+
+        private string _tempJsonFile;
+
+        [SetUp]
+        public void Setup()
+        {
+            _loggerMock = new Mock<ILog>();
+            Configuration.Initialize(_loggerMock.Object);
+
+            var rawJson = @"{
+	                    ""AgentDebug"": true,
+	                    ""AgentVerboseDebug"": true,
+	                    ""AllowNodeDebug"": true,
+	                    
+	                    ""AgentDirectory"": ""C:/dev/cody/agent/dist"",
+	                    
+	                    ""RemoteAgentPort"": 3113,
+	                    
+	                    ""Trace"": true,
+	                    ""TraceFile"": ""C:/tmp/cody.log"",
+	                    
+	                    ""TraceLogioHostname"": ""localhost"",
+	                    ""TraceLogioPort"": 6689,
+	                    
+	                    ""ShowCodyAgentOutput"": true,
+	                    ""ShowCodyNotificationsOutput"": true
+                    }";
+            _tempJsonFile = Path.GetTempFileName();
+            File.WriteAllText(_tempJsonFile, rawJson);
+        }
+
+        [Test]
+        public void Parsing_Json_Dev_Config_Should_Not_Call_LoggerError()
+        {
+            // given
+
+            // when
+            Configuration.AddFromJsonFile(_tempJsonFile);
+            int? remoteAgentPort = Configuration.RemoteAgentPort;
+            int? traceLogioPort = Configuration.TraceLogioPort;
+
+            // then
+            _loggerMock.Verify(x => x.Error(It.IsAny<string>(), It.IsAny<Exception>(), It.IsAny<string>()), Times.Never);
+            Assert.That(remoteAgentPort, Is.Not.Null);
+            Assert.That(traceLogioPort, Is.Not.Null);
+        }
+
+        [TearDown]
+        public void CleanUp()
+        {
+            if (File.Exists(_tempJsonFile))
+                File.Delete(_tempJsonFile);
+        }
+    }
+}

--- a/src/Cody.Core.Tests/ConfiguartionFileJsonTests.cs
+++ b/src/Cody.Core.Tests/ConfiguartionFileJsonTests.cs
@@ -46,18 +46,30 @@ namespace Cody.Core.Tests
         }
 
         [Test]
-        public void Parsing_Json_Dev_Config_Should_Not_Call_LoggerError()
+        public void Parsing_Json_Dev_Config_Should_Not_Call_LoggerError_When_Accessing_RemoteAgentPort()
         {
             // given
 
             // when
             Configuration.AddFromJsonFile(_tempJsonFile);
             int? remoteAgentPort = Configuration.RemoteAgentPort;
-            int? traceLogioPort = Configuration.TraceLogioPort;
 
             // then
             _loggerMock.Verify(x => x.Error(It.IsAny<string>(), It.IsAny<Exception>(), It.IsAny<string>()), Times.Never);
             Assert.That(remoteAgentPort, Is.Not.Null);
+        }
+
+        [Test]
+        public void Parsing_Json_Dev_Config_Should_Not_Call_LoggerError_When_Accessing_TraceLogioPort()
+        {
+            // given
+
+            // when
+            Configuration.AddFromJsonFile(_tempJsonFile);
+            int? traceLogioPort = Configuration.TraceLogioPort;
+
+            // then
+            _loggerMock.Verify(x => x.Error(It.IsAny<string>(), It.IsAny<Exception>(), It.IsAny<string>()), Times.Never);
             Assert.That(traceLogioPort, Is.Not.Null);
         }
 

--- a/src/Cody.Core/Common/Configuration.Setup.cs
+++ b/src/Cody.Core/Common/Configuration.Setup.cs
@@ -4,12 +4,20 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using Cody.Core.Logging;
 
 namespace Cody.Core.Common
 {
     public static partial class Configuration
     {
-        private static Dictionary<string, object> config = new Dictionary<string, object>();
+        private static readonly Dictionary<string, object> _config = new Dictionary<string, object>();
+
+        private static ILog _logger;
+
+        public static void Initialize(ILog logger)
+        {
+            _logger = logger;
+        }
 
         public static void AddFromJsonFile(string path)
         {
@@ -20,8 +28,14 @@ namespace Cody.Core.Common
                     var json = File.ReadAllText(path);
                     var configuration = JsonConvert.DeserializeObject<Dictionary<string, object>>(json);
                     AddFromDictionary(configuration);
+
+                    _logger.Debug("Configuration loaded.");
+                    _logger.Debug(json);
                 }
-                catch { }
+                catch (Exception ex)
+                {
+                    _logger.Error($"Failed loading configuration from: '{path}'", ex);
+                }
             }
         }
 
@@ -31,18 +45,30 @@ namespace Cody.Core.Common
             AddFromJsonFile(path);
         }
 
-        public static void AddFromDictionary(Dictionary<string, object> dictionary)
+        private static void AddFromDictionary(Dictionary<string, object> dictionary)
         {
             if (dictionary == null) return;
 
             foreach (var pair in dictionary)
             {
-                if (config.ContainsKey(pair.Key)) config[pair.Key] = pair.Value;
-                else config.Add(pair.Key, pair.Value);
+                if (_config.ContainsKey(pair.Key)) _config[pair.Key] = pair.Value;
+                else _config.Add(pair.Key, pair.Value);
             }
         }
 
-        private static T Get<T>(T defaultValue, [CallerMemberName] string key = null) => (T)(config.TryGetValue(key, out object value) ? value : defaultValue);
+        private static T Get<T>(T defaultValue, [CallerMemberName] string key = null)
+        {
+            try
+            {
+                return (T)(_config.TryGetValue(key, out object value) ? value : defaultValue);
+            }
+            catch (Exception ex)
+            {
+                _logger.Error($"Cannot get value for key:'{key}'", ex);
+            }
+
+            return defaultValue;
+        }
 
 
         public static bool IsDebug

--- a/src/Cody.Core/Common/Configuration.cs
+++ b/src/Cody.Core/Common/Configuration.cs
@@ -14,7 +14,7 @@ namespace Cody.Core.Common
 
         public static string AgentDirectory => Get((string)null);
 
-        public static int? RemoteAgentPort => Get((int?)null);
+        public static int? RemoteAgentPort => (int?)Get((long?)null);
 
         public static bool Trace => Get(false);
 
@@ -22,7 +22,7 @@ namespace Cody.Core.Common
 
         public static string TraceLogioHostname => Get((string)null);
 
-        public static int? TraceLogioPort => Get((int?)null);
+        public static int? TraceLogioPort => (int?)Get((long?)null);
 
         public static bool ShowCodyAgentOutput => Get(false);
 

--- a/src/Cody.VisualStudio/Cody.VisualStudio.csproj
+++ b/src/Cody.VisualStudio/Cody.VisualStudio.csproj
@@ -1,168 +1,169 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <MinimumVisualStudioVersion>17.0</MinimumVisualStudioVersion>
-    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
-  </PropertyGroup>
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectTypeGuids>{82b43b9b-a64c-4715-b499-d71e9ca2bd60};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <ProjectGuid>{3BB34F98-F069-4A38-BC4D-CF407D59B863}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Cody.VisualStudio</RootNamespace>
-    <AssemblyName>Cody.VisualStudio</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
-    <GeneratePkgDefFile>true</GeneratePkgDefFile>
-    <UseCodebase>true</UseCodebase>
-    <IncludeAssemblyInVSIXContainer>true</IncludeAssemblyInVSIXContainer>
-    <IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>
-    <IncludeDebugSymbolsInLocalVSIXDeployment>false</IncludeDebugSymbolsInLocalVSIXDeployment>
-    <CopyBuildOutputToOutputDirectory>true</CopyBuildOutputToOutputDirectory>
-    <CopyOutputSymbolsToOutputDirectory>true</CopyOutputSymbolsToOutputDirectory>
-    <StartAction>Program</StartAction>
-    <StartProgram Condition="'$(DevEnvDir)' != ''">$(DevEnvDir)devenv.exe</StartProgram>
-    <StartArguments>/rootsuffix Exp</StartArguments>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <NoWarn>VSTHRD010;VSTHRD200;VSTHRD105;VSTHRD100</NoWarn>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <ItemGroup>
-    <Compile Include="Client\AgentClient.cs" />
-    <Compile Include="Client\AgentClientOptions.cs" />
-    <Compile Include="Client\AgentProcessConnector.cs" />
-    <Compile Include="Client\IAgentConnector.cs" />
-    <Compile Include="Client\NameTransformer.cs" />
-    <Compile Include="Client\RemoteAgentConnector.cs" />
-    <Compile Include="Client\TraceJsonRpc.cs" />
-    <Compile Include="CodyPackage.ErrorHandling.cs" />
-    <Compile Include="CodyToolWindow.cs" />
-    <Compile Include="Infrastructure\LoggerFactory.cs" />
-    <Compile Include="Infrastructure\WindowPaneLogger.cs" />
-    <Compile Include="Infrastructure\VsConstants.cs" />
-    <Compile Include="CommandIDs.cs" />
-    <Compile Include="Guids.cs" />
-    <Compile Include="Options\GeneralOptionsPage.cs">
-      <SubType>Component</SubType>
-    </Compile>
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="CodyPackage.cs" />
-    <Compile Include="Services\SecretStorageService.cs" />
-    <Compile Include="Services\DocumentsSyncService.cs" />
-    <Compile Include="Services\FileService.cs" />
-    <Compile Include="Services\ProgressService.cs" />
-    <Compile Include="Services\SolutionService.cs" />
-    <Compile Include="Services\TestingSupportService.cs" />
-    <Compile Include="Services\ThemeService.cs" />
-    <Compile Include="Services\StatusbarService.cs" />
-    <Compile Include="Services\UserSettingsProvider.cs" />
-    <Compile Include="Services\VsVersionService.cs" />
-    <Compile Include="Utilities\FilePathHelper.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include="Resources\sourcegraph.png">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <None Include="..\CodyDevConfig.json">
-      <Link>CodyDevConfig.json</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="publishManifest.json" />
-    <None Include="..\..\README.md">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="source.extension.vsixmanifest">
-      <SubType>Designer</SubType>
-    </None>
-    <Content Include="Agent\*.*">
-      <IncludeInVSIX>true</IncludeInVSIX>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Remove="Agent\index.js.map" Condition="'$(Configuration)' == 'Release'" />
-    <Content Include="Agent\webviews\*.*">
-      <IncludeInVSIX>true</IncludeInVSIX>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
-  <ItemGroup>
-    <Reference Include="PresentationCore" />
-    <Reference Include="PresentationFramework" />
-    <Reference Include="System" />
-    <Reference Include="System.Design" />
-    <Reference Include="System.Drawing" />
-    <Reference Include="WindowsBase" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.0-previews-4-31709-430" ExcludeAssets="runtime" />
+    <PropertyGroup>
+        <MinimumVisualStudioVersion>17.0</MinimumVisualStudioVersion>
+        <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    </PropertyGroup>
+    <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+    <PropertyGroup>
+        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+        <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+        <SchemaVersion>2.0</SchemaVersion>
+        <ProjectTypeGuids>{82b43b9b-a64c-4715-b499-d71e9ca2bd60};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+        <ProjectGuid>{3BB34F98-F069-4A38-BC4D-CF407D59B863}</ProjectGuid>
+        <OutputType>Library</OutputType>
+        <AppDesignerFolder>Properties</AppDesignerFolder>
+        <RootNamespace>Cody.VisualStudio</RootNamespace>
+        <AssemblyName>Cody.VisualStudio</AssemblyName>
+        <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+        <GeneratePkgDefFile>true</GeneratePkgDefFile>
+        <UseCodebase>true</UseCodebase>
+        <IncludeAssemblyInVSIXContainer>true</IncludeAssemblyInVSIXContainer>
+        <IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>
+        <IncludeDebugSymbolsInLocalVSIXDeployment>false</IncludeDebugSymbolsInLocalVSIXDeployment>
+        <CopyBuildOutputToOutputDirectory>true</CopyBuildOutputToOutputDirectory>
+        <CopyOutputSymbolsToOutputDirectory>true</CopyOutputSymbolsToOutputDirectory>
+        <StartAction>Program</StartAction>
+        <StartProgram Condition="'$(DevEnvDir)' != ''">$(DevEnvDir)devenv.exe</StartProgram>
+        <StartArguments>/rootsuffix Exp</StartArguments>
+    </PropertyGroup>
+    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+        <DebugSymbols>true</DebugSymbols>
+        <DebugType>full</DebugType>
+        <Optimize>false</Optimize>
+        <OutputPath>bin\Debug\</OutputPath>
+        <DefineConstants>DEBUG;TRACE</DefineConstants>
+        <ErrorReport>prompt</ErrorReport>
+        <WarningLevel>4</WarningLevel>
+        <NoWarn>VSTHRD010;VSTHRD200;VSTHRD105;VSTHRD100</NoWarn>
+    </PropertyGroup>
+    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+        <DebugType>pdbonly</DebugType>
+        <Optimize>true</Optimize>
+        <OutputPath>bin\Release\</OutputPath>
+        <DefineConstants>TRACE</DefineConstants>
+        <ErrorReport>prompt</ErrorReport>
+        <WarningLevel>4</WarningLevel>
+    </PropertyGroup>
+    <ItemGroup>
+        <Compile Include="Client\AgentClient.cs" />
+        <Compile Include="Client\AgentClientOptions.cs" />
+        <Compile Include="Client\AgentProcessConnector.cs" />
+        <Compile Include="Client\IAgentConnector.cs" />
+        <Compile Include="Client\NameTransformer.cs" />
+        <Compile Include="Client\RemoteAgentConnector.cs" />
+        <Compile Include="Client\TraceJsonRpc.cs" />
+        <Compile Include="CodyPackage.ErrorHandling.cs" />
+        <Compile Include="CodyToolWindow.cs" />
+        <Compile Include="Infrastructure\LoggerFactory.cs" />
+        <Compile Include="Infrastructure\WindowPaneLogger.cs" />
+        <Compile Include="Infrastructure\VsConstants.cs" />
+        <Compile Include="CommandIDs.cs" />
+        <Compile Include="Guids.cs" />
+        <Compile Include="Options\GeneralOptionsPage.cs">
+            <SubType>Component</SubType>
+        </Compile>
+        <Compile Include="Properties\AssemblyInfo.cs" />
+        <Compile Include="CodyPackage.cs" />
+        <Compile Include="Services\SecretStorageService.cs" />
+        <Compile Include="Services\DocumentsSyncService.cs" />
+        <Compile Include="Services\FileService.cs" />
+        <Compile Include="Services\ProgressService.cs" />
+        <Compile Include="Services\SolutionService.cs" />
+        <Compile Include="Services\TestingSupportService.cs" />
+        <Compile Include="Services\ThemeService.cs" />
+        <Compile Include="Services\StatusbarService.cs" />
+        <Compile Include="Services\UserSettingsProvider.cs" />
+        <Compile Include="Services\VsVersionService.cs" />
+        <Compile Include="Utilities\FilePathHelper.cs" />
+    </ItemGroup>
+    <ItemGroup Condition="'$(Configuration)' == 'Debug'">
+        <Content Include="..\CodyDevConfig.json">
+            <IncludeInVSIX>true</IncludeInVSIX>
+        </Content>
+    </ItemGroup>
+    <ItemGroup>
+        <Content Include="Resources\sourcegraph.png">
+            <IncludeInVSIX>true</IncludeInVSIX>
+        </Content>
+        <None Include="publishManifest.json" />
+        <None Include="..\..\README.md">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+        <None Include="source.extension.vsixmanifest">
+            <SubType>Designer</SubType>
+        </None>
+        <Content Include="Agent\*.*">
+            <IncludeInVSIX>true</IncludeInVSIX>
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
+        <Content Remove="Agent\index.js.map" Condition="'$(Configuration)' == 'Release'" />
+        <Content Include="Agent\webviews\*.*">
+            <IncludeInVSIX>true</IncludeInVSIX>
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
+    </ItemGroup>
+    <ItemGroup>
+        <Reference Include="PresentationCore" />
+        <Reference Include="PresentationFramework" />
+        <Reference Include="System" />
+        <Reference Include="System.Design" />
+        <Reference Include="System.Drawing" />
+        <Reference Include="WindowsBase" />
+    </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.0-previews-4-31709-430" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.6.2164">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
-  <ItemGroup>
-    <VSCTCompile Include="CodyPackage.vsct">
-      <ResourceName>Menus.ctmenu</ResourceName>
-    </VSCTCompile>
-    <Content Include="Resources\CodyToolWindowCommand.png" />
-  </ItemGroup>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+    <ItemGroup>
+        <VSCTCompile Include="CodyPackage.vsct">
+            <ResourceName>Menus.ctmenu</ResourceName>
+        </VSCTCompile>
+        <Content Include="Resources\CodyToolWindowCommand.png" />
+    </ItemGroup>
 
-  <!--Completions dll start -->
+    <!--Completions dll start -->
 
-  <!--Workaround to get Cody.VisualStudio.Completions compiled when using Visual Studio to run and debug the extension
+    <!--Workaround to get Cody.VisualStudio.Completions compiled when using Visual Studio to run and debug the extension
   Only works with Visual Studio, but unfortunately not with msbuild-->
-  <Target Name="Completions" BeforeTargets="GetVsixSourceItems"
-          Condition="'$(BuildingInsideVisualStudio)' == 'true'"
+    <Target Name="Completions" BeforeTargets="GetVsixSourceItems"
+            Condition="'$(BuildingInsideVisualStudio)' == 'true'"
           >
-      <MSBuild Projects="..\Cody.VisualStudio.Completions\Cody.VisualStudio.Completions.csproj"
-               Properties="Configuration=$(Configuration)"
-               Targets="Build" />
-  </Target>
+        <MSBuild Projects="..\Cody.VisualStudio.Completions\Cody.VisualStudio.Completions.csproj"
+                 Properties="Configuration=$(Configuration)"
+                 Targets="Build" />
+    </Target>
 
-  <Target Name="CopyCompletionsDllToVsix" BeforeTargets="GetVsixSourceItems">
-      <PropertyGroup>
-          <CompletionsDllPath>..\Cody.VisualStudio.Completions\bin\$(Configuration)\Cody.VisualStudio.Completions.dll</CompletionsDllPath>
-      </PropertyGroup>
+    <Target Name="CopyCompletionsDllToVsix" BeforeTargets="GetVsixSourceItems">
+        <PropertyGroup>
+            <CompletionsDllPath>..\Cody.VisualStudio.Completions\bin\$(Configuration)\Cody.VisualStudio.Completions.dll</CompletionsDllPath>
+        </PropertyGroup>
 
-      <ItemGroup Condition="Exists('$(CompletionsDllPath)')">
-          <VSIXSourceItem Include="$(CompletionsDllPath)">
-              <VSIXSubPath>.</VSIXSubPath>
-          </VSIXSourceItem>
-      </ItemGroup>
-  </Target>
-  <!--Completions dll end -->
+        <ItemGroup Condition="Exists('$(CompletionsDllPath)')">
+            <VSIXSourceItem Include="$(CompletionsDllPath)">
+                <VSIXSubPath>.</VSIXSubPath>
+            </VSIXSourceItem>
+        </ItemGroup>
+    </Target>
+    <!--Completions dll end -->
 
-  <ItemGroup>
-    <ProjectReference Include="..\Cody.Core\Cody.Core.csproj">
-      <Project>{9FF2CC40-78E9-46C8-B2EF-30A1F1BE82F2}</Project>
-      <Name>Cody.Core</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Cody.UI\Cody.UI.csproj">
-      <Project>{7BE6018E-01DA-4404-A56E-6478A0D513FC}</Project>
-      <Name>Cody.UI</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup />
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+    <ItemGroup>
+        <ProjectReference Include="..\Cody.Core\Cody.Core.csproj">
+            <Project>{9FF2CC40-78E9-46C8-B2EF-30A1F1BE82F2}</Project>
+            <Name>Cody.Core</Name>
+        </ProjectReference>
+        <ProjectReference Include="..\Cody.UI\Cody.UI.csproj">
+            <Project>{7BE6018E-01DA-4404-A56E-6478A0D513FC}</Project>
+            <Name>Cody.UI</Name>
+        </ProjectReference>
+    </ItemGroup>
+    <ItemGroup />
+    <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+    <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
+    <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>


### PR DESCRIPTION
Resolves JSON deserialization issues where port values were being parsed as `int` instead of `long` types. Added error handling, logging, and comprehensive test coverage for configuration file parsing scenarios.

`CodyDevConfig.json` is now included in VSIX installer in Debug mode and used during run-time.


## Test plan

1. Uncomment RemoteAgentPort and TraceLogioPort in `CodyDevConfig.json` and observe output window for any errors when accesing those properties from `Configuration` class.
