### PR TITLE
Parses version string even when it contains postfix

### DIFF
--- a/src/Cody.VisualStudio/Services/VsVersionService.cs
+++ b/src/Cody.VisualStudio/Services/VsVersionService.cs
@@ -1,9 +1,10 @@
 using Cody.Core.Ide;
+using Cody.Core.Logging;
+using Microsoft.VisualStudio.Settings;
 using Microsoft.VisualStudio.Shell;
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using Cody.Core.Logging;
 
 namespace Cody.VisualStudio.Services
 {
@@ -21,12 +22,20 @@ namespace Cody.VisualStudio.Services
                 DisplayVersion = GetAppIdStringProperty(VSAPropID.ProductDisplayVersion);
                 EditionName = GetAppIdStringProperty(VSAPropID.EditionName);
 
-                Version = Version.Parse(DisplayVersion);
+                Version = ParseVersion(DisplayVersion);
             }
             catch (Exception ex)
             {
                 _logger.Error("Retrieving VS version failed.", ex);
             }
+        }
+
+        private Version ParseVersion(string version)
+        {
+            int spaceIndex = version.IndexOf(' ');
+            if (spaceIndex >= 0) version = version.Substring(0, spaceIndex).Trim();
+
+            return Version.Parse(version);
         }
 
 


### PR DESCRIPTION
Visual Studio preview versions contain a postfix in the version number (e.g. “17.14.2 preview 2”), which prevents the version from being parsed correctly. This PR checks if postfix exists and cuts it out before parsing.

## Test plan
N/A
<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->
