### PR TITLE
Use of the shutdown state in Cody logic

### DIFF
--- a/src/Cody.Core/Logging/SentryLog.cs
+++ b/src/Cody.Core/Logging/SentryLog.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Threading;
 
 namespace Cody.Core.Logging
 {
@@ -67,7 +68,7 @@ namespace Cody.Core.Logging
             }
         }
 
-        public static void Initialize()
+        public static void Initialize(CancellationToken shutdownToken)
         {
             if (!Configuration.IsDebug && !Debugger.IsAttached)
             {
@@ -93,6 +94,7 @@ namespace Cody.Core.Logging
                         if (se.Message != null) return se;
                         if (se.Contexts.ContainsKey(ErrorData)) return se;
                         if (se.SentryExceptions == null) return se;
+                        if (se.Exception is ObjectDisposedException && shutdownToken.IsCancellationRequested) return null;
 
                         foreach (var ex in se.SentryExceptions)
                         {

--- a/src/Cody.UI/Controls/WebView2Dev.xaml.cs
+++ b/src/Cody.UI/Controls/WebView2Dev.xaml.cs
@@ -1,4 +1,6 @@
 using Cody.Core.Agent;
+using Cody.Core.Common;
+using Cody.Core.Logging;
 using Microsoft.Web.WebView2.Core;
 using System;
 using System.Diagnostics;
@@ -8,8 +10,6 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
-using Cody.Core.Logging;
-using Cody.Core.Common;
 
 namespace Cody.UI.Controls
 {

--- a/src/Cody.UI/Controls/WebviewController.cs
+++ b/src/Cody.UI/Controls/WebviewController.cs
@@ -5,6 +5,7 @@ using Microsoft.Web.WebView2.Core;
 using System;
 using System.IO;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
@@ -105,6 +106,11 @@ namespace Cody.UI.Controls
             catch (TaskCanceledException)
             {
                 System.Diagnostics.Debug.WriteLine(message, "Agent PostWebMessageAsJson task canceled");
+            }
+            catch (InvalidOperationException ex) when (ex.InnerException is COMException)
+            {
+                //CoreWebView2 members cannot be accessed after the WebView2 control is disposed.
+                System.Diagnostics.Debug.WriteLine(ex.Message);
             }
             catch (AggregateException ex) when (ex.InnerException is InvalidOperationException inex)
             {

--- a/src/Cody.VisualStudio.Completions/LoggerFactory.cs
+++ b/src/Cody.VisualStudio.Completions/LoggerFactory.cs
@@ -1,11 +1,11 @@
-using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.ComponentModel.Composition;
 using Cody.Core.Logging;
 using Cody.VisualStudio.Inf;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
 
 namespace Cody.VisualStudio.Completions
 {
@@ -30,7 +30,7 @@ namespace Cody.VisualStudio.Completions
             try
             {
                 sentryLog = new SentryLog();
-                SentryLog.Initialize();
+                SentryLog.Initialize(VsShellUtilities.ShutdownToken);
                 logger = new Logger();
 
                 var failToCreateWindowPaneLogger = false;

--- a/src/Cody.VisualStudio/Client/AgentClient.cs
+++ b/src/Cody.VisualStudio/Client/AgentClient.cs
@@ -2,6 +2,7 @@ using Cody.Core.Agent;
 using Cody.Core.Agent.Protocol;
 using Cody.Core.Logging;
 using Cody.Core.Trace;
+using Microsoft.VisualStudio.Shell;
 using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Serialization;
 using StreamJsonRpc;
@@ -79,6 +80,8 @@ namespace Cody.VisualStudio.Client
 
         private void OnDisconnected(object sender, JsonRpcDisconnectedEventArgs e)
         {
+            if (VsShellUtilities.ShutdownToken.IsCancellationRequested) return;
+
             if (e.Exception != null)
                 log.Error($"Agent disconnected due to {e.Description} (reason: {e.Reason})", e.Exception);
             else
@@ -124,7 +127,7 @@ namespace Cody.VisualStudio.Client
             //to many calls to sentry
             //else log.Error($"The agent connection unexpectedly ended with code {exitCode}.");
 
-            if (options.RestartAgentOnFailure && exitCode != 0)
+            if (options.RestartAgentOnFailure && exitCode != 0 && !VsShellUtilities.ShutdownToken.IsCancellationRequested)
             {
                 log.Info("Restarting the agent.");
 

--- a/src/Cody.VisualStudio/CodyPackage.ErrorHandling.cs
+++ b/src/Cody.VisualStudio/CodyPackage.ErrorHandling.cs
@@ -1,4 +1,5 @@
 using Cody.Core.Logging;
+using Microsoft.VisualStudio.Shell;
 using System;
 using System.Linq;
 using System.Text;
@@ -16,7 +17,7 @@ namespace Cody.VisualStudio
             Application.Current.DispatcherUnhandledException += CurrentOnDispatcherUnhandledException;
             TaskScheduler.UnobservedTaskException += TaskSchedulerOnUnobservedTaskException;
 
-            SentryLog.Initialize();
+            SentryLog.Initialize(VsShellUtilities.ShutdownToken);
         }
 
 


### PR DESCRIPTION
Add support for Visual Studio shutdown state in the extension. So far, Cody has not used the information that the IDE is about to shut down and tried to continue working. This led to many resource dispose exceptions during app exit. This PR adds support for shutdown state and reduces number of errors logged to Sentry.
## Test plan
N/A
<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->
