### PR TITLE
Revert "Hide auto-edit"

### DIFF
--- a/src/Cody.Core/Settings/UserSettingsService.cs
+++ b/src/Cody.Core/Settings/UserSettingsService.cs
@@ -123,7 +123,7 @@ namespace Cody.Core.Settings
         {
             get
             {
-                var value = GetOrDefault(nameof(EnableAutoEdit), false.ToString());
+                var value = GetOrDefault(nameof(EnableAutoEdit), true.ToString());
                 return bool.Parse(value);
             }
             set => Set(nameof(EnableAutoEdit), value.ToString());

--- a/src/Cody.UI/Controls/Options/GeneralOptionsControl.xaml
+++ b/src/Cody.UI/Controls/Options/GeneralOptionsControl.xaml
@@ -117,7 +117,6 @@
                     IsChecked="{Binding EnableAutoEdit, Mode=TwoWay}"
                     Content="Enable Cody auto-edit (requires restart)"
                     IsEnabled="{Binding HasCompletionSupport}"
-                    Visibility="Hidden"
                    />
 
                 <!--Get Help-->


### PR DESCRIPTION
Reverts sourcegraph/cody-vs#301 and unhide autoedit
## Test plan
N/A
<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->