### PR TITLE
Improve Visual Studio themes

### DIFF
--- a/src/Cody.VisualStudio/Services/ThemeService.cs
+++ b/src/Cody.VisualStudio/Services/ThemeService.cs
@@ -1,4 +1,5 @@
 using Cody.Core.Infrastructure;
+using Cody.Core.Logging;
 using Microsoft.VisualStudio.PlatformUI;
 using Microsoft.VisualStudio.Settings;
 using Microsoft.VisualStudio.Shell;
@@ -11,7 +12,6 @@ using System.Drawing;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
-using Cody.Core.Logging;
 
 namespace Cody.VisualStudio.Services
 {
@@ -304,6 +304,12 @@ namespace Cody.VisualStudio.Services
             EnvironmentColors.StatusBarHighlightColorKey,
             EnvironmentColors.StatusBarNoSolutionColorKey,
             EnvironmentColors.StatusBarTextColorKey,
+            EnvironmentColors.CommandBarMenuIconBackgroundColorKey,
+            //EnvironmentColors.CommandBarMenuItemMouseOverTextColorKey,
+            EnvironmentColors.CommandBarMenuItemMouseOverColorKey,
+            EnvironmentColors.SystemMenuTextColorKey,
+            EnvironmentColors.CommandBarMenuWatermarkTextColorKey,
+            EnvironmentColors.CommandBarMenuSeparatorColorKey,
         };
     }
 }


### PR DESCRIPTION
CLOSE https://linear.app/sourcegraph/issue/CODY-6146/visual-studio-theme-accessibility-issue

These changes [together with 8152](https://github.com/sourcegraph/cody/pull/8152) improve menu coloring in the chat window and in the @ menu. The change is mainly visible in blue/blue (extra contrast) themes.

Before
![Before](https://github.com/user-attachments/assets/8569eb84-a2b8-4852-bd8f-1a70c665e8a4)

After
![After](https://github.com/user-attachments/assets/ac745803-a4e1-4a38-a5f9-949a0d5adccb)
## Test plan
Change the theme color to Blue (extra contrast) and compare with the screenshot above.
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
