### PR TITLE
Check if connector is not null during shutdown 

### DIFF
--- a/src/Cody.VisualStudio/Client/AgentClient.cs
+++ b/src/Cody.VisualStudio/Client/AgentClient.cs
@@ -146,10 +146,13 @@ namespace Cody.VisualStudio.Client
 
         private void DisconnectInternal()
         {
-            if (!jsonRpc.IsDisposed) jsonRpc.Dispose();
-            connector.ErrorReceived -= OnErrorReceived;
-            connector.Disconnected -= OnAgentDisconnected;
-            connector.Disconnect();
+            if (!jsonRpc.IsDisposed) jsonRpc?.Dispose();
+            if (connector != null)
+            {
+                connector.ErrorReceived -= OnErrorReceived;
+                connector.Disconnected -= OnAgentDisconnected;
+                connector.Disconnect();
+            }
 
             jsonRpc = null;
             connector = null;


### PR DESCRIPTION
Adding a check to see if the connector to the agent is not null during the VS shutdown process
## Test plan
N/A
<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->
