### PR TITLE
Change of login level when agent is disconnecting

### DIFF
--- a/src/Cody.VisualStudio/Client/AgentClient.cs
+++ b/src/Cody.VisualStudio/Client/AgentClient.cs
@@ -85,7 +85,7 @@ namespace Cody.VisualStudio.Client
             if (e.Exception != null)
                 log.Error($"Agent disconnected due to {e.Description} (reason: {e.Reason})", e.Exception);
             else
-                log.Error($"Agent disconnected due to {e.Description} (reason: {e.Reason})");
+                log.Info($"Agent disconnected due to {e.Description} (reason: {e.Reason})");
         }
 
         private void CreateAgentService()


### PR DESCRIPTION
This PR changes the logging level from Error to Info for the case when the agent is disconnecting (e.g. when the IDE is shutting down).
## Test plan
N/A
<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->
