### PR TITLE
Webview2 version update

### DIFF
--- a/src/Cody.UI/Cody.UI.csproj
+++ b/src/Cody.UI/Cody.UI.csproj
@@ -88,7 +88,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.0-previews-4-31709-430" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Web.WebView2">
-      <Version>1.0.3296.44</Version>
+      <Version>1.0.3351.48</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup />


### PR DESCRIPTION
Upgrade webview2 component to 1.0.3351.48 version.
## Test plan
N/A
<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->
