### PR TITLE
Filtering out exceptions not related to Cody

### DIFF
--- a/src/Cody.Core/Common/StringExtensions.cs
+++ b/src/Cody.Core/Common/StringExtensions.cs
@@ -16,7 +16,7 @@ namespace Cody.Core.Common
                 var uri = new Uri("file:///" + path).AbsoluteUri;
                 return Regex.Replace(uri, "(file:///)(\\D+)(:)", m => m.Groups[1].Value + m.Groups[2].Value.ToLower() + "%3A");
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
                 ex.Data.Add("path", path);
                 throw;
@@ -26,6 +26,11 @@ namespace Cody.Core.Common
         public static string ConvertLineBreaks(this string text, string lineBrakeChars)
         {
             return Regex.Replace(text, @"\r\n?|\n", lineBrakeChars);
+        }
+
+        public static bool ContainsIgnoreCase(this string source, string toCheck)
+        {
+            return source?.IndexOf(toCheck, StringComparison.OrdinalIgnoreCase) >= 0;
         }
     }
 }

--- a/src/Cody.VisualStudio/CodyPackage.ErrorHandling.cs
+++ b/src/Cody.VisualStudio/CodyPackage.ErrorHandling.cs
@@ -1,3 +1,4 @@
+using Cody.Core.Common;
 using Cody.Core.Logging;
 using Microsoft.VisualStudio.Shell;
 using System;
@@ -20,14 +21,32 @@ namespace Cody.VisualStudio
             SentryLog.Initialize(VsShellUtilities.ShutdownToken);
         }
 
+        private bool ShouldLogException(Exception ex)
+        {
+            const string cody = "cody";
+            if (ex.Message.ContainsIgnoreCase(cody) ||
+                ex.Source.ContainsIgnoreCase(cody) ||
+                ex.StackTrace.ContainsIgnoreCase(cody))
+            {
+                return true;
+            }
+            else
+            {
+                if (ex.InnerException != null) return ShouldLogException(ex.InnerException);
+                else return false;
+            }
+        }
 
 
         private void CurrentDomainOnUnhandledException(object sender, UnhandledExceptionEventArgs e)
         {
+            var exception = e.ExceptionObject as Exception;
+            if (exception != null && !ShouldLogException(exception)) return;
+
             Logger.Error($"Unhandled domain exception:{e.ExceptionObject}");
             Logger.Error($"Unhandled domain exception, is terminating:{e.IsTerminating}");
 
-            var exception = e.ExceptionObject as Exception;
+
             Logger.Error("Unhandled domain exception occurred.", exception);
 
         }
@@ -35,8 +54,9 @@ namespace Cody.VisualStudio
         private void CurrentOnDispatcherUnhandledException(object sender, DispatcherUnhandledExceptionEventArgs e)
         {
             var exception = e.Exception;
-            Logger.Error("Unhandled exception occurred on the UI thread.", exception);
+            if (!ShouldLogException(exception)) return;
 
+            Logger.Error("Unhandled exception occurred on the UI thread.", exception);
             if (!System.Diagnostics.Debugger.IsAttached)
                 e.Handled = true;
         }

--- a/src/Cody.VisualStudio/CodyPackage.ErrorHandling.cs
+++ b/src/Cody.VisualStudio/CodyPackage.ErrorHandling.cs
@@ -21,7 +21,7 @@ namespace Cody.VisualStudio
             SentryLog.Initialize(VsShellUtilities.ShutdownToken);
         }
 
-        private bool ShouldLogException(Exception ex)
+        private bool IsCodyException(Exception ex)
         {
             const string cody = "cody";
             if (ex.Message.ContainsIgnoreCase(cody) ||
@@ -32,7 +32,7 @@ namespace Cody.VisualStudio
             }
             else
             {
-                if (ex.InnerException != null) return ShouldLogException(ex.InnerException);
+                if (ex.InnerException != null) return IsCodyException(ex.InnerException);
                 else return false;
             }
         }
@@ -41,7 +41,7 @@ namespace Cody.VisualStudio
         private void CurrentDomainOnUnhandledException(object sender, UnhandledExceptionEventArgs e)
         {
             var exception = e.ExceptionObject as Exception;
-            if (exception != null && !ShouldLogException(exception)) return;
+            if (exception != null && !IsCodyException(exception)) return;
 
             Logger.Error($"Unhandled domain exception:{e.ExceptionObject}");
             Logger.Error($"Unhandled domain exception, is terminating:{e.IsTerminating}");
@@ -54,7 +54,7 @@ namespace Cody.VisualStudio
         private void CurrentOnDispatcherUnhandledException(object sender, DispatcherUnhandledExceptionEventArgs e)
         {
             var exception = e.Exception;
-            if (!ShouldLogException(exception)) return;
+            if (!IsCodyException(exception)) return;
 
             Logger.Error("Unhandled exception occurred on the UI thread.", exception);
             if (!System.Diagnostics.Debugger.IsAttached)

--- a/src/Cody.VisualStudio/CodyPackage.cs
+++ b/src/Cody.VisualStudio/CodyPackage.cs
@@ -34,7 +34,6 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
-using EnvDTE;
 using Configuration = Cody.Core.Common.Configuration;
 using SolutionEvents = Microsoft.VisualStudio.Shell.Events.SolutionEvents;
 using Task = System.Threading.Tasks.Task;
@@ -89,7 +88,6 @@ namespace Cody.VisualStudio
 
         protected override async Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
         {
-
             try
             {
                 InitializeErrorHandling();
@@ -98,11 +96,10 @@ namespace Cody.VisualStudio
                 LoadDevConfiguration();
 
                 await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
-
                 InitializeTrace();
                 InitializeServices(loggerFactory);
                 await InitOleMenu();
-                
+
                 InitializeAgent();
 
                 ReportSentryVsVersion();
@@ -145,7 +142,7 @@ namespace Cody.VisualStudio
         {
             AgentLogger = loggerFactory.Create(Configuration.ShowCodyAgentOutput ? WindowPaneLogger.CodyAgent : null);
             AgentNotificationsLogger = loggerFactory.Create(Configuration.ShowCodyNotificationsOutput ? WindowPaneLogger.CodyNotifications : null);
-         
+
 
             var vsSolution = this.GetService<SVsSolution, IVsSolution>();
             SolutionService = new SolutionService(vsSolution, Logger);
@@ -308,7 +305,7 @@ namespace Cody.VisualStudio
                         {
                             InfobarNotifications = new InfobarNotifications(host, uiFactory, AgentNotificationsLogger);
                             _infobarNotificationsCompletionSource.SetResult(InfobarNotifications);
-                            
+
                         }
                         else
                         {


### PR DESCRIPTION
Exceptions not related to Cody go to Sentry. This is caused by reporting all unhandled exceptions from VS. This change causes logging of exceptions that have something to do with Cody.
## Test plan
N/A
<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->
