### PR TITLE
The agent debugging improvements via TCP connection

### DIFF
--- a/src/Cody.VisualStudio/Client/AgentClient.cs
+++ b/src/Cody.VisualStudio/Client/AgentClient.cs
@@ -108,7 +108,7 @@ namespace Cody.VisualStudio.Client
             IAgentConnector connector;
             if (options.ConnectToRemoteAgent)
             {
-                connector = new RemoteAgentConnector();
+                connector = new RemoteAgentConnector(log);
                 log.Info("Remote agent connector created");
             }
             else

--- a/src/Cody.VisualStudio/Client/RemoteAgentConnector.cs
+++ b/src/Cody.VisualStudio/Client/RemoteAgentConnector.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Net.Sockets;
 using System.Net;
 using System.Threading;
+using System.Threading.Tasks;
 using Cody.Core.Logging;
 
 namespace Cody.VisualStudio.Client
@@ -46,9 +47,15 @@ namespace Cody.VisualStudio.Client
         {
             if (client != null && client.Connected)
             {
+                _logger.Debug("Disconnecting from remote agent...");
                 client.Close();
                 client = null;
+                _logger.Info("Successfully disconnected from remote agent");
                 Disconnected?.Invoke(this, 0);
+            }
+            else
+            {
+                _logger.Debug("Disconnect called but client is not connected");
             }
         }
 

--- a/src/Cody.VisualStudio/Client/RemoteAgentConnector.cs
+++ b/src/Cody.VisualStudio/Client/RemoteAgentConnector.cs
@@ -13,6 +13,8 @@ namespace Cody.VisualStudio.Client
         private readonly ILog _logger;
         private TcpClient client;
 
+        private TimeSpan _defaultTimeout = TimeSpan.FromMinutes(5);
+
         public RemoteAgentConnector(ILog logger)
         {
             _logger = logger;
@@ -23,7 +25,8 @@ namespace Cody.VisualStudio.Client
 
         public void Connect(AgentClientOptions options)
         {
-            while (true)
+            var timeout = DateTime.UtcNow.Add(_defaultTimeout);
+            while (DateTime.UtcNow < timeout)
             {
                 try
                 {
@@ -41,6 +44,8 @@ namespace Cody.VisualStudio.Client
                     Thread.Sleep(TimeSpan.FromSeconds(5));
                 }
             }
+            
+            _logger.Error($"Failed to connect to remote agent within {_defaultTimeout.TotalMinutes} minutes timeout");
         }
 
         public void Disconnect()
@@ -51,6 +56,7 @@ namespace Cody.VisualStudio.Client
                 client.Close();
                 client = null;
                 _logger.Info("Successfully disconnected from remote agent");
+
                 Disconnected?.Invoke(this, 0);
             }
             else

--- a/src/Cody.VisualStudio/Client/RemoteAgentConnector.cs
+++ b/src/Cody.VisualStudio/Client/RemoteAgentConnector.cs
@@ -1,25 +1,45 @@
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Net.Sockets;
 using System.Net;
-using System.Text;
-using System.Threading.Tasks;
+using System.Threading;
+using Cody.Core.Logging;
 
 namespace Cody.VisualStudio.Client
 {
     public class RemoteAgentConnector : IAgentConnector
     {
+        private readonly ILog _logger;
         private TcpClient client;
+
+        public RemoteAgentConnector(ILog logger)
+        {
+            _logger = logger;
+        }
 
         public event EventHandler<int> Disconnected;
         public event EventHandler<string> ErrorReceived;
 
         public void Connect(AgentClientOptions options)
         {
-            client = new TcpClient();
-            client.Connect(IPAddress.Loopback, options.RemoteAgentPort);
+            while (true)
+            {
+                try
+                {
+                    _logger.Debug($"Try to connect to port:{options.RemoteAgentPort} ...");
+
+                    client = new TcpClient();
+                    client.Connect(IPAddress.Loopback, options.RemoteAgentPort);
+                    return;
+                }
+                catch
+                {
+                    client.Close();
+                    client.Dispose();
+
+                    Thread.Sleep(TimeSpan.FromSeconds(5));
+                }
+            }
         }
 
         public void Disconnect()


### PR DESCRIPTION
1. Added Connection Retry Logic with Timeout 
   - Implemented 5-minute timeout for connection attempts
   - Added retry mechanism with 5-second intervals between attempts
   - Enhanced error handling for TCP connection failures
2. Improved Logging and Debugging 
   - Added detailed disconnect logging with debug and info messages
   - Enhanced connection status tracking


## Test plan

1. Uncomment `RemoteAgentPort` section in `CodyDevConfig.json` file
2. Run Cody in Debug mode
3. Check if Cody is trying to connect via TCP port

```
[ProcessId:15532] [ThreadId:15] Debug [RemoteAgentConnector.Connect] Try to connect to port:3113 ...
```
