### PR TITLE
Updated agent version to remove PLG login options.

### DIFF
--- a/agent/agent.version
+++ b/agent/agent.version
@@ -1,1 +1,1 @@
-vscode-v1.108.0
+vscode-v1.114.0


### PR DESCRIPTION
Update Cody agent to v1.114.0, which removes PLG login options.


## Test plan

1. PLG login options aren't showing up.
