### PR TITLE
WebView2 library downgrade

### DIFF
--- a/src/Cody.UI/Cody.UI.csproj
+++ b/src/Cody.UI/Cody.UI.csproj
@@ -88,7 +88,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.0-previews-4-31709-430" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Web.WebView2">
-      <Version>1.0.3351.48</Version>
+      <Version>1.0.2592.51</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup />

--- a/src/Cody.UI/Controls/CodyWebView2.cs
+++ b/src/Cody.UI/Controls/CodyWebView2.cs
@@ -3,7 +3,7 @@ using System.Windows.Input;
 
 namespace Cody.UI.Controls
 {
-    public class CodyWebView2 : WebView2CompositionControl
+    public class CodyWebView2 : WebView2
     {
         protected override void OnPreviewKeyDown(KeyEventArgs e)
         {


### PR DESCRIPTION
After updating `Microsoft.Web.WebView2` to version `1.0.3296.44` some users have started reporting problems with the chat rendering (an empty Cody window).

Looks like last update to `1.0.3351.48` doesn't resolve the issue also, so downgrading to `1.0.2592.51` which is the last good working version. Unfortunately it does not have fix for https://github.com/MicrosoftEdge/WebView2Feedback/issues/286 (WebView2 is always on the top of the other controls).

Users are reporting a blank Cody window, but looks like internally that the page is loaded, and when interacting with the control the cursor is changing and reacting to different page areas (e. g. buttons).

More context: https://sourcegraph.slack.com/archives/C073U3KE5DK/p1753121170575139

Probably related:
1. https://github.com/MicrosoftEdge/WebView2Feedback/issues/5189
2. https://github.com/MicrosoftEdge/WebView2Feedback/issues/5281

<img width="1401" height="747" alt="obraz" src="https://github.com/user-attachments/assets/a76d3c0f-4a28-403f-ba06-0790bf999523" />



## Test plan

Monitoring affected users after they will update the extension (no working repro steps at this moment).
