### PR TITLE
Build-in prompts commands

### DIFF
--- a/src/Cody.Core/Agent/IAgentService.cs
+++ b/src/Cody.Core/Agent/IAgentService.cs
@@ -80,6 +80,9 @@ namespace Cody.Core.Agent
         [AgentCall("testing/workspaceDocuments")]
         Task<GetDocumentsResult> GetWorkspaceDocuments(GetDocumentsParams documents);
 
+        [AgentCall("command/execute")]
+        Task CommandExecute(ExecuteCommandParams command);
+
         //---------------------------------------------------------
         // For notifications return type MUST be void!
         //---------------------------------------------------------

--- a/src/Cody.Core/Agent/Protocol/ExecuteCommandParams.cs
+++ b/src/Cody.Core/Agent/Protocol/ExecuteCommandParams.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Cody.Core.Agent.Protocol
+{
+    public class ExecuteCommandParams
+    {
+        public string Command { get; set; }
+        public object[] Arguments { get; set; }
+    }
+}

--- a/src/Cody.Core/Cody.Core.csproj
+++ b/src/Cody.Core/Cody.Core.csproj
@@ -61,6 +61,7 @@
     <Compile Include="Agent\Protocol\AutoeditChanges.cs" />
     <Compile Include="Agent\Protocol\AutoeditImageDiff.cs" />
     <Compile Include="Agent\Protocol\ChatPanelInfo.cs" />
+    <Compile Include="Agent\Protocol\ExecuteCommandParams.cs" />
     <Compile Include="Agent\Protocol\ShowWindowMessageParams.cs" />
     <Compile Include="Agent\Protocol\CodyFileRename.cs" />
     <Compile Include="Agent\Protocol\AutoeditTextDiff.cs" />

--- a/src/Cody.Core/Infrastructure/IStatusbarService.cs
+++ b/src/Cody.Core/Infrastructure/IStatusbarService.cs
@@ -9,5 +9,9 @@ namespace Cody.Core.Infrastructure
     public interface IStatusbarService
     {
         void SetText(string text);
+
+        void StartProgressAnimation();
+
+        void StopProgressAnimation();
     }
 }

--- a/src/Cody.VisualStudio/Cody.VisualStudio.csproj
+++ b/src/Cody.VisualStudio/Cody.VisualStudio.csproj
@@ -53,6 +53,7 @@
     <Compile Include="Client\NameTransformer.cs" />
     <Compile Include="Client\RemoteAgentConnector.cs" />
     <Compile Include="Client\TraceJsonRpc.cs" />
+    <Compile Include="CodyPackage.Commands.cs" />
     <Compile Include="CodyPackage.ErrorHandling.cs" />
     <Compile Include="CodyToolWindow.cs" />
     <Compile Include="Infrastructure\LoggerFactory.cs" />
@@ -117,42 +118,33 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.0-previews-4-31709-430" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.6.2164">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-    </ItemGroup>
-    <ItemGroup>
-        <VSCTCompile Include="CodyPackage.vsct">
-            <ResourceName>Menus.ctmenu</ResourceName>
-        </VSCTCompile>
-        <Content Include="Resources\CodyToolWindowCommand.png" />
-    </ItemGroup>
-
-    <!--Completions dll start -->
-
-    <!--Workaround to get Cody.VisualStudio.Completions compiled when using Visual Studio to run and debug the extension
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <VSCTCompile Include="CodyPackage.vsct">
+      <ResourceName>Menus.ctmenu</ResourceName>
+    </VSCTCompile>
+    <Content Include="Resources\CodyToolWindowCommand.png" />
+  </ItemGroup>
+  <!--Completions dll start -->
+  <!--Workaround to get Cody.VisualStudio.Completions compiled when using Visual Studio to run and debug the extension
   Only works with Visual Studio, but unfortunately not with msbuild-->
-    <Target Name="Completions" BeforeTargets="GetVsixSourceItems"
-            Condition="'$(BuildingInsideVisualStudio)' == 'true'"
-          >
-        <MSBuild Projects="..\Cody.VisualStudio.Completions\Cody.VisualStudio.Completions.csproj"
-                 Properties="Configuration=$(Configuration)"
-                 Targets="Build" />
-    </Target>
-
-    <Target Name="CopyCompletionsDllToVsix" BeforeTargets="GetVsixSourceItems">
-        <PropertyGroup>
-            <CompletionsDllPath>..\Cody.VisualStudio.Completions\bin\$(Configuration)\Cody.VisualStudio.Completions.dll</CompletionsDllPath>
-        </PropertyGroup>
-
-        <ItemGroup Condition="Exists('$(CompletionsDllPath)')">
-            <VSIXSourceItem Include="$(CompletionsDllPath)">
-                <VSIXSubPath>.</VSIXSubPath>
-            </VSIXSourceItem>
-        </ItemGroup>
-    </Target>
-    <!--Completions dll end -->
-
+  <Target Name="Completions" BeforeTargets="GetVsixSourceItems" Condition="'$(BuildingInsideVisualStudio)' == 'true'">
+    <MSBuild Projects="..\Cody.VisualStudio.Completions\Cody.VisualStudio.Completions.csproj" Properties="Configuration=$(Configuration)" Targets="Build" />
+  </Target>
+  <Target Name="CopyCompletionsDllToVsix" BeforeTargets="GetVsixSourceItems">
+    <PropertyGroup>
+      <CompletionsDllPath>..\Cody.VisualStudio.Completions\bin\$(Configuration)\Cody.VisualStudio.Completions.dll</CompletionsDllPath>
+    </PropertyGroup>
+    <ItemGroup Condition="Exists('$(CompletionsDllPath)')">
+      <VSIXSourceItem Include="$(CompletionsDllPath)">
+        <VSIXSubPath>.</VSIXSubPath>
+      </VSIXSourceItem>
+    </ItemGroup>
+  </Target>
+  <!--Completions dll end -->
   <ItemGroup>
     <ProjectReference Include="..\Cody.Core\Cody.Core.csproj">
       <Project>{9FF2CC40-78E9-46C8-B2EF-30A1F1BE82F2}</Project>

--- a/src/Cody.VisualStudio/Cody.VisualStudio.csproj
+++ b/src/Cody.VisualStudio/Cody.VisualStudio.csproj
@@ -118,33 +118,42 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.0-previews-4-31709-430" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.6.2164">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
-  <ItemGroup>
-    <VSCTCompile Include="CodyPackage.vsct">
-      <ResourceName>Menus.ctmenu</ResourceName>
-    </VSCTCompile>
-    <Content Include="Resources\CodyToolWindowCommand.png" />
-  </ItemGroup>
-  <!--Completions dll start -->
-  <!--Workaround to get Cody.VisualStudio.Completions compiled when using Visual Studio to run and debug the extension
-  Only works with Visual Studio, but unfortunately not with msbuild-->
-  <Target Name="Completions" BeforeTargets="GetVsixSourceItems" Condition="'$(BuildingInsideVisualStudio)' == 'true'">
-    <MSBuild Projects="..\Cody.VisualStudio.Completions\Cody.VisualStudio.Completions.csproj" Properties="Configuration=$(Configuration)" Targets="Build" />
-  </Target>
-  <Target Name="CopyCompletionsDllToVsix" BeforeTargets="GetVsixSourceItems">
-    <PropertyGroup>
-      <CompletionsDllPath>..\Cody.VisualStudio.Completions\bin\$(Configuration)\Cody.VisualStudio.Completions.dll</CompletionsDllPath>
-    </PropertyGroup>
-    <ItemGroup Condition="Exists('$(CompletionsDllPath)')">
-      <VSIXSourceItem Include="$(CompletionsDllPath)">
-        <VSIXSubPath>.</VSIXSubPath>
-      </VSIXSourceItem>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
     </ItemGroup>
-  </Target>
-  <!--Completions dll end -->
+    <ItemGroup>
+        <VSCTCompile Include="CodyPackage.vsct">
+            <ResourceName>Menus.ctmenu</ResourceName>
+        </VSCTCompile>
+        <Content Include="Resources\CodyToolWindowCommand.png" />
+    </ItemGroup>
+
+    <!--Completions dll start -->
+
+    <!--Workaround to get Cody.VisualStudio.Completions compiled when using Visual Studio to run and debug the extension
+  Only works with Visual Studio, but unfortunately not with msbuild-->
+    <Target Name="Completions" BeforeTargets="GetVsixSourceItems"
+            Condition="'$(BuildingInsideVisualStudio)' == 'true'"
+          >
+        <MSBuild Projects="..\Cody.VisualStudio.Completions\Cody.VisualStudio.Completions.csproj"
+                 Properties="Configuration=$(Configuration)"
+                 Targets="Build" />
+    </Target>
+
+    <Target Name="CopyCompletionsDllToVsix" BeforeTargets="GetVsixSourceItems">
+        <PropertyGroup>
+            <CompletionsDllPath>..\Cody.VisualStudio.Completions\bin\$(Configuration)\Cody.VisualStudio.Completions.dll</CompletionsDllPath>
+        </PropertyGroup>
+
+        <ItemGroup Condition="Exists('$(CompletionsDllPath)')">
+            <VSIXSourceItem Include="$(CompletionsDllPath)">
+                <VSIXSubPath>.</VSIXSubPath>
+            </VSIXSourceItem>
+        </ItemGroup>
+    </Target>
+    <!--Completions dll end -->
+
   <ItemGroup>
     <ProjectReference Include="..\Cody.Core\Cody.Core.csproj">
       <Project>{9FF2CC40-78E9-46C8-B2EF-30A1F1BE82F2}</Project>

--- a/src/Cody.VisualStudio/CodyPackage.Commands.cs
+++ b/src/Cody.VisualStudio/CodyPackage.Commands.cs
@@ -66,10 +66,15 @@ namespace Cody.VisualStudio
                 if (codyCommands.TryGetValue(commandId, out var command))
                 {
                     if (commandId == CommandIds.ExplainCodeCommandId ||
-                        commandId == CommandIds.FindCodeSmellsCommandId)
+                        commandId == CommandIds.FindCodeSmellsCommandId ||
+                        commandId == CommandIds.GenerateUnitTestsCommandId)
                     {
                         Logger.Debug($"Showing the chat window for the {command} command");
                         await ShowToolWindowAsync();
+                    }
+                    else
+                    {
+                        StatusbarService?.StartProgressAnimation();
                     }
 
                     if (AgentClient != null)

--- a/src/Cody.VisualStudio/CodyPackage.Commands.cs
+++ b/src/Cody.VisualStudio/CodyPackage.Commands.cs
@@ -1,0 +1,123 @@
+using Cody.Core.Agent.Protocol;
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Design;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Cody.VisualStudio
+{
+    public partial class CodyPackage
+    {
+        private readonly Dictionary<int, string> codyCommandMap = new Dictionary<int, string>()
+        {
+            [CommandIds.DocumentCodeCommandId] = "cody.command.document-code",
+            [CommandIds.GenerateUnitTestsCommandId] = "cody.command.unit-test",
+            [CommandIds.ExplainCodeCommandId] = "cody.command.explain-code",
+            [CommandIds.FindCodeSmellsCommandId] = "cody.command.smell-code",
+        };
+
+        private async Task InitOleMenu()
+        {
+            try
+            {
+                if (await GetServiceAsync(typeof(IMenuCommandService)) is OleMenuCommandService oleMenuService)
+                {
+                    var commandId = new CommandID(Guids.CodyPackageCommandSet, CommandIds.CodyToolWindow);
+                    oleMenuService.AddCommand(new MenuCommand(ShowToolWindow, commandId));
+
+
+                    var documentCodeCmdId = new CommandID(Guids.CodyPackageCommandSet, CommandIds.DocumentCodeCommandId);
+                    oleMenuService.AddCommand(new MenuCommand(InvokeCodyCommand, documentCodeCmdId));
+
+                    var generateUnitTestsCmdId = new CommandID(Guids.CodyPackageCommandSet, CommandIds.GenerateUnitTestsCommandId);
+                    oleMenuService.AddCommand(new MenuCommand(InvokeCodyCommand, generateUnitTestsCmdId));
+
+                    var explainCodeCmdId = new CommandID(Guids.CodyPackageCommandSet, CommandIds.ExplainCodeCommandId);
+                    oleMenuService.AddCommand(new MenuCommand(InvokeCodyCommand, explainCodeCmdId));
+
+                    var findCodeSmellsCmdId = new CommandID(Guids.CodyPackageCommandSet, CommandIds.FindCodeSmellsCommandId);
+                    oleMenuService.AddCommand(new MenuCommand(InvokeCodyCommand, findCodeSmellsCmdId));
+                }
+                else
+                {
+                    throw new NotSupportedException($"Cannot get {nameof(OleMenuCommandService)}");
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger?.Error("Cannot initialize menu items", ex);
+            }
+        }
+
+        public async void InvokeCodyCommand(object sender, EventArgs eventArgs)
+        {
+            try
+            {
+                var menuCommand = sender as MenuCommand;
+                if (menuCommand == null)
+                {
+                    Logger.Error("Cannot get MenuCommand instance");
+                    return;
+                }
+
+                var commandId = menuCommand.CommandID.ID;
+
+                if (codyCommandMap.TryGetValue(commandId, out string command))
+                {
+                    if (commandId == CommandIds.ExplainCodeCommandId ||
+                       commandId == CommandIds.FindCodeSmellsCommandId)
+                    {
+                        Logger.Debug($"Showing the chat window for the {command} command");
+                        await ShowToolWindowAsync();
+                    }
+
+                    Logger.Info($"Invoking command: {command}");
+                    await AgentService.CommandExecute(new ExecuteCommandParams
+                    {
+                        Command = command
+                    });
+                }
+                else Logger.Error($"Cant find command for id: {commandId}");
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"Failed to invoke command", ex);
+            }
+
+        }
+
+        public async void ShowToolWindow(object sender, EventArgs eventArgs) => await ShowToolWindowAsync();
+
+        public async Task ShowToolWindowAsync()
+        {
+            try
+            {
+                Logger.Debug("Showing Tool Window ...");
+                var window = await ShowToolWindowAsync(typeof(CodyToolWindow), 0, true, DisposalToken);
+                if (window?.Frame is IVsWindowFrame windowFrame)
+                {
+                    bool isVisible = windowFrame.IsVisible() == 0;
+                    bool isOnScreen = windowFrame.IsOnScreen(out int screenTmp) == 0 && screenTmp == 1;
+
+                    Logger.Debug($"IsVisible:{isVisible} IsOnScreen:{isOnScreen}");
+
+                    if (!isVisible || !isOnScreen)
+                    {
+                        ErrorHandler.ThrowOnFailure(windowFrame.Show());
+                        Logger.Debug("Shown.");
+
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Error("Cannot toggle Tool Window.", ex);
+            }
+        }
+    }
+}

--- a/src/Cody.VisualStudio/CodyPackage.cs
+++ b/src/Cody.VisualStudio/CodyPackage.cs
@@ -187,7 +187,7 @@ namespace Cody.VisualStudio
             FileDialogService = new FileDialogService(SolutionService, Logger);
 
             ProgressNotificationHandlers = new ProgressNotificationHandlers(ProgressService);
-            TextDocumentNotificationHandlers = new TextDocumentNotificationHandlers(DocumentService, FileDialogService);
+            TextDocumentNotificationHandlers = new TextDocumentNotificationHandlers(DocumentService, FileDialogService, StatusbarService);
 
 
 

--- a/src/Cody.VisualStudio/CodyPackage.cs
+++ b/src/Cody.VisualStudio/CodyPackage.cs
@@ -272,26 +272,6 @@ namespace Cody.VisualStudio
             await ShowToolWindowAsync();
         }
 
-        private async Task InitOleMenu()
-        {
-            try
-            {
-                if (await GetServiceAsync(typeof(IMenuCommandService)) is OleMenuCommandService oleMenuService)
-                {
-                    var commandId = new CommandID(Guids.CodyPackageCommandSet, (int)CommandIds.CodyToolWindow);
-                    oleMenuService.AddCommand(new MenuCommand(ShowToolWindow, commandId));
-                }
-                else
-                {
-                    throw new NotSupportedException($"Cannot get {nameof(OleMenuCommandService)}");
-                }
-            }
-            catch (Exception ex)
-            {
-                Logger?.Error("Cannot initialize menu items", ex);
-            }
-        }
-
         private void InitializeNotificationsBar()
         {
             try
@@ -330,38 +310,6 @@ namespace Cody.VisualStudio
             catch (Exception ex)
             {
                 Logger.Error("Cannot initialize InfoBarLicensePreordersService.", ex);
-            }
-        }
-
-        public async void ShowToolWindow(object sender, EventArgs eventArgs)
-        {
-            await ShowToolWindowAsync();
-        }
-
-        public async Task ShowToolWindowAsync()
-        {
-            try
-            {
-                Logger.Debug("Showing Tool Window ...");
-                var window = await ShowToolWindowAsync(typeof(CodyToolWindow), 0, true, DisposalToken);
-                if (window?.Frame is IVsWindowFrame windowFrame)
-                {
-                    bool isVisible = windowFrame.IsVisible() == 0;
-                    bool isOnScreen = windowFrame.IsOnScreen(out int screenTmp) == 0 && screenTmp == 1;
-
-                    Logger.Debug($"IsVisible:{isVisible} IsOnScreen:{isOnScreen}");
-
-                    if (!isVisible || !isOnScreen)
-                    {
-                        ErrorHandler.ThrowOnFailure(windowFrame.Show());
-                        Logger.Debug("Shown.");
-
-                    }
-                }
-            }
-            catch (Exception ex)
-            {
-                Logger.Error("Cannot toggle Tool Window.", ex);
             }
         }
 

--- a/src/Cody.VisualStudio/CodyPackage.vsct
+++ b/src/Cody.VisualStudio/CodyPackage.vsct
@@ -178,10 +178,14 @@
             <IDSymbol name="bmpPicArrows" value="5" />
             <IDSymbol name="bmpPicStrikethrough" value="6" />
         </GuidSymbol>
+
+        <GuidSymbol name="guidTextEditor" value="{8B382828-6202-11D1-8870-0000F87579D2}" />
     </Symbols>
 
     <KeyBindings>
         <!-- This is the keybinding for opening chat. -->
         <KeyBinding guid="guidCodyPackageCmdSet" id="CodyToolWindowCommandId" editor="guidVSStd97" key1="L" mod1="Alt" />
+        <KeyBinding guid="guidCodyPackageCmdSet" id="DocumentCodeCommandId" editor="guidTextEditor" key1="K" mod1="Alt" />
+        <KeyBinding guid="guidCodyPackageCmdSet" id="ExplainCodeCommandId" editor="guidTextEditor" key1="I" mod1="Alt" />
     </KeyBindings>
 </CommandTable>

--- a/src/Cody.VisualStudio/CodyPackage.vsct
+++ b/src/Cody.VisualStudio/CodyPackage.vsct
@@ -92,11 +92,12 @@
             <Button guid="guidCodyPackageCmdSet" id="DocumentCodeCommandId" priority="0x0100" type="Button">
                 <Parent guid="guidCodyPackageCmdSet" id="CodySubmenuGroup" />
                 <Icon guid="ImageCatalogGuid" id="ShowAllCode" />
+                <CommandFlag>DynamicVisibility</CommandFlag>
+                <CommandFlag>DefaultInvisible</CommandFlag>
                 <CommandFlag>IconIsMoniker</CommandFlag>
                 <Strings>
                     <ButtonText>Document Code</ButtonText>
-                    <CanonicalName>Cody.DocumentCode</CanonicalName>
-                    <LocCanonicalName>Cody.DocumentCode</LocCanonicalName>
+                    <CanonicalName>DocumentCode</CanonicalName>
                     <ToolTipText>Documents the selected code</ToolTipText>
                 </Strings>
             </Button>
@@ -104,11 +105,12 @@
             <Button guid="guidCodyPackageCmdSet" id="GenerateUnitTestsCommandId" priority="0x0200" type="Button">
                 <Parent guid="guidCodyPackageCmdSet" id="CodySubmenuGroup" />
                 <Icon guid="ImageCatalogGuid" id="CodeTest" />
+                <CommandFlag>DynamicVisibility</CommandFlag>
+                <CommandFlag>DefaultInvisible</CommandFlag>
                 <CommandFlag>IconIsMoniker</CommandFlag>
                 <Strings>
                     <ButtonText>Generate Unit Tests</ButtonText>
-                    <CanonicalName>Cody.GenerateUnitTests</CanonicalName>
-                    <LocCanonicalName>Cody.GenerateUnitTests</LocCanonicalName>
+                    <CanonicalName>GenerateUnitTests</CanonicalName>
                     <ToolTipText>Generates unit tests for the selected code</ToolTipText>
                 </Strings>
             </Button>
@@ -116,11 +118,12 @@
             <Button guid="guidCodyPackageCmdSet" id="ExplainCodeCommandId" priority="0x0300" type="Button">
                 <Parent guid="guidCodyPackageCmdSet" id="CodySubmenuGroup" />
                 <Icon guid="ImageCatalogGuid" id="CodeReviewDashboard" />
+                <CommandFlag>DynamicVisibility</CommandFlag>
+                <CommandFlag>DefaultInvisible</CommandFlag>
                 <CommandFlag>IconIsMoniker</CommandFlag>
                 <Strings>
                     <ButtonText>Explain Code</ButtonText>
-                    <CanonicalName>Cody.ExplainCode</CanonicalName>
-                    <LocCanonicalName>Cody.ExplainCode</LocCanonicalName>
+                    <CanonicalName>ExplainCode</CanonicalName>
                     <ToolTipText>Explain the selected code</ToolTipText>
                 </Strings>
             </Button>
@@ -128,11 +131,12 @@
             <Button guid="guidCodyPackageCmdSet" id="FindCodeSmellsCommandId" priority="0x0400" type="Button">
                 <Parent guid="guidCodyPackageCmdSet" id="CodySubmenuGroup" />
                 <Icon guid="ImageCatalogGuid" id="CodeInformation" />
+                <CommandFlag>DynamicVisibility</CommandFlag>
+                <CommandFlag>DefaultInvisible</CommandFlag>
                 <CommandFlag>IconIsMoniker</CommandFlag>
                 <Strings>
                     <ButtonText>Find Code Smells</ButtonText>
-                    <CanonicalName>Cody.FindCodeSmells</CanonicalName>
-                    <LocCanonicalName>Cody.FindCodeSmells</LocCanonicalName>
+                    <CanonicalName>FindCodeSmells</CanonicalName>
                     <ToolTipText>Find code smells in the selected code</ToolTipText>
                 </Strings>
             </Button>

--- a/src/Cody.VisualStudio/CodyPackage.vsct
+++ b/src/Cody.VisualStudio/CodyPackage.vsct
@@ -1,73 +1,84 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <CommandTable xmlns="http://schemas.microsoft.com/VisualStudio/2005-10-18/CommandTable" xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
-	<!--  This is the file that defines the actual layout and type of the commands.
+    <!--  This is the file that defines the actual layout and type of the commands.
         It is divided in different sections (e.g. command definition, command
         placement, ...), with each defining a specific set of properties.
         See the comment before each section for more details about how to
         use it. -->
 
-	<!--  The VSCT compiler (the tool that translates this file into the binary
+    <!--  The VSCT compiler (the tool that translates this file into the binary
         format that VisualStudio will consume) has the ability to run a preprocessor
         on the vsct file; this preprocessor is (usually) the C++ preprocessor, so
         it is possible to define includes and macros with the same syntax used
         in C++ files. Using this ability of the compiler here, we include some files
         defining some of the constants that we will use inside the file. -->
 
-	<!--This is the file that defines the IDs for all the commands exposed by VisualStudio. -->
-	<Extern href="stdidcmd.h"/>
+    <!--This is the file that defines the IDs for all the commands exposed by VisualStudio. -->
+    <Extern href="stdidcmd.h"/>
 
-	<!--This header contains the command ids for the menus provided by the shell. -->
-	<Extern href="vsshlids.h"/>
+    <!--This header contains the command ids for the menus provided by the shell. -->
+    <Extern href="vsshlids.h"/>
 
-	<!--The Commands section is where commands, menus, and menu groups are defined.
+    <Include href="KnownImageIds.vsct"/>
+
+    <!--The Commands section is where commands, menus, and menu groups are defined.
       This section uses a Guid to identify the package that provides the command defined inside it. -->
-	<Commands package="guidCodyPackage">
-		<!-- Inside this section we have different sub-sections: one for the menus, another
+    <Commands package="guidCodyPackage">
+        <!-- Inside this section we have different sub-sections: one for the menus, another
     for the menu groups, one for the buttons (the actual commands), one for the combos
     and the last one for the bitmaps used. Each element is identified by a command id that
     is a unique pair of guid and numeric identifier; the guid part of the identifier is usually
     called "command set" and is used to group different command inside a logically related
     group; your package should define its own command set in order to avoid collisions
     with command ids defined by other packages. -->
-		<Groups>
+        <!-- Add Menus section for the submenu -->
+        <Menus>
+            <!-- Submenu in the editor context menu -->
+            <Menu guid="guidCodyPackageCmdSet" id="CodySubmenu" priority="0x0100" type="Menu">
+                <Parent guid="guidCodyPackageCmdSet" id="CodyEditorContextMenuGroup"/>
+                <Strings>
+                    <ButtonText>Cody</ButtonText>
+                    <MenuText>Cody</MenuText>
+                </Strings>
+            </Menu>
+        </Menus>
+        <Groups>
             <Group guid="guidCodyPackageCmdSet" id="CodyToolsMenuGroup" priority="0x0100">
                 <Parent guid="guidSHLMainMenu" id="IDM_VS_MENU_TOOLS"/>
             </Group>
-            <!-- Context Menu group -->
-			<Group guid="guidCodyPackageCmdSet" id="CodyEditorContextMenuGroup" priority="0x0100">
-				<Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_CODEWIN"/>
-			</Group>
-		</Groups>
-		<!--Buttons section. -->
-		<!--This section defines the elements the user can interact with, like a menu command or a button
+            <!-- Context Menu group - this goes directly in the editor context menu -->
+            <Group guid="guidCodyPackageCmdSet" id="CodyEditorContextMenuGroup" priority="0xD000">
+                <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_CODEWIN"/>
+            </Group>
+
+            <!-- Group for items inside the Cody submenu -->
+            <Group guid="guidCodyPackageCmdSet" id="CodySubmenuGroup" priority="0x0100">
+                <Parent guid="guidCodyPackageCmdSet" id="CodySubmenu"/>
+            </Group>
+        </Groups>
+        <!--Buttons section. -->
+        <!--This section defines the elements the user can interact with, like a menu command or a button
         or combo box in a toolbar. -->
-		<Buttons>
-			<!--To define a menu group you have to specify its ID, the parent menu and its display priority.
+        <Buttons>
+            <!--To define a menu group you have to specify its ID, the parent menu and its display priority.
           The command is visible and enabled by default. If you need to change the visibility, status, etc, you can use
           the CommandFlag node.
           You can add more than one CommandFlag node e.g.:
               <CommandFlag>DefaultInvisible</CommandFlag>
               <CommandFlag>DynamicVisibility</CommandFlag>
           If you do not want an image next to your command, remove the Icon node /> -->
-			<Button guid="guidCodyPackageCmdSet" id="CodyToolWindowCommandId" priority="0x0100" type="Button">
-				<Parent guid="guidSHLMainMenu" id="IDG_VS_WNDO_OTRWNDWS1"/>
-				<Icon guid="guidImages" id="bmpPic1" />
-				<CommandFlag>DynamicVisibility</CommandFlag>
-				<Strings>
-					<ButtonText>Cody Chat</ButtonText>
-				</Strings>
-			</Button>
-			<!-- New button in the editor context menu -->
-			<Button guid="guidCodyPackageCmdSet" id="CodyToolWindowCommandId" priority="0x0100" type="Button">
-				<Parent guid="guidCodyPackageCmdSet" id="CodyEditorContextMenuGroup" />
-				<Icon guid="guidImages" id="bmpPic1" />
-				<CommandFlag>DynamicVisibility</CommandFlag>
-				<Strings>
-					<ButtonText>Cody Chat</ButtonText>
-				</Strings>
-			</Button>
-            <!-- New button in the toolbar -->
+            <Button guid="guidCodyPackageCmdSet" id="CodyToolWindowCommandId" priority="0x0100" type="Button">
+                <Parent guid="guidSHLMainMenu" id="IDG_VS_WNDO_OTRWNDWS1"/>
+                <Icon guid="guidImages" id="bmpPic1" />
+                <CommandFlag>DynamicVisibility</CommandFlag>
+                <Strings>
+                    <CanonicalName>Cody.Chat</CanonicalName>
+                    <LocCanonicalName>Cody.Chat</LocCanonicalName>
+                    <ButtonText>Cody Chat</ButtonText>
+                </Strings>
+            </Button>
+            <!-- Cody in Tools menu -->
             <Button guid="guidCodyPackageCmdSet" id="CodyToolWindowCommandId" priority="0x100" type="Button">
                 <Parent guid="guidCodyPackageCmdSet" id="CodyToolsMenuGroup"/>
                 <Icon guid="guidImages" id="bmpPic1"/>
@@ -76,41 +87,97 @@
                     <ButtonText>Cody</ButtonText>
                 </Strings>
             </Button>
-		</Buttons>
-		<!--The bitmaps section is used to define the bitmaps that are used for the commands.-->
-		<Bitmaps>
-			<!--  The bitmap id is defined in a way that is a little bit different from the others:
+
+            <!-- Document Code button in the submenu -->
+            <Button guid="guidCodyPackageCmdSet" id="DocumentCodeCommandId" priority="0x0100" type="Button">
+                <Parent guid="guidCodyPackageCmdSet" id="CodySubmenuGroup" />
+                <Icon guid="ImageCatalogGuid" id="ShowAllCode" />
+                <CommandFlag>IconIsMoniker</CommandFlag>
+                <Strings>
+                    <ButtonText>Document Code</ButtonText>
+                    <CanonicalName>Cody.DocumentCode</CanonicalName>
+                    <LocCanonicalName>Cody.DocumentCode</LocCanonicalName>
+                    <ToolTipText>Documents the selected code</ToolTipText>
+                </Strings>
+            </Button>
+            <!-- Generate Unit Tests button in the submenu -->
+            <Button guid="guidCodyPackageCmdSet" id="GenerateUnitTestsCommandId" priority="0x0200" type="Button">
+                <Parent guid="guidCodyPackageCmdSet" id="CodySubmenuGroup" />
+                <Icon guid="ImageCatalogGuid" id="CodeTest" />
+                <CommandFlag>IconIsMoniker</CommandFlag>
+                <Strings>
+                    <ButtonText>Generate Unit Tests</ButtonText>
+                    <CanonicalName>Cody.GenerateUnitTests</CanonicalName>
+                    <LocCanonicalName>Cody.GenerateUnitTests</LocCanonicalName>
+                    <ToolTipText>Generates unit tests for the selected code</ToolTipText>
+                </Strings>
+            </Button>
+            <!-- Explain Code button in the submenu -->
+            <Button guid="guidCodyPackageCmdSet" id="ExplainCodeCommandId" priority="0x0300" type="Button">
+                <Parent guid="guidCodyPackageCmdSet" id="CodySubmenuGroup" />
+                <Icon guid="ImageCatalogGuid" id="CodeReviewDashboard" />
+                <CommandFlag>IconIsMoniker</CommandFlag>
+                <Strings>
+                    <ButtonText>Explain Code</ButtonText>
+                    <CanonicalName>Cody.ExplainCode</CanonicalName>
+                    <LocCanonicalName>Cody.ExplainCode</LocCanonicalName>
+                    <ToolTipText>Explain the selected code</ToolTipText>
+                </Strings>
+            </Button>
+            <!-- Find Code Smells button in the submenu -->
+            <Button guid="guidCodyPackageCmdSet" id="FindCodeSmellsCommandId" priority="0x0400" type="Button">
+                <Parent guid="guidCodyPackageCmdSet" id="CodySubmenuGroup" />
+                <Icon guid="ImageCatalogGuid" id="CodeInformation" />
+                <CommandFlag>IconIsMoniker</CommandFlag>
+                <Strings>
+                    <ButtonText>Find Code Smells</ButtonText>
+                    <CanonicalName>Cody.FindCodeSmells</CanonicalName>
+                    <LocCanonicalName>Cody.FindCodeSmells</LocCanonicalName>
+                    <ToolTipText>Find code smells in the selected code</ToolTipText>
+                </Strings>
+            </Button>
+        </Buttons>
+        <!--The bitmaps section is used to define the bitmaps that are used for the commands.-->
+        <Bitmaps>
+            <!--  The bitmap id is defined in a way that is a little bit different from the others:
             the declaration starts with a guid for the bitmap strip, then there is the resource id of the
             bitmap strip containing the bitmaps and then there are the numeric ids of the elements used
             inside a button definition. An important aspect of this declaration is that the element id
             must be the actual index (1-based) of the bitmap inside the bitmap strip. -->
-			<Bitmap guid="guidImages" href="Resources\CodyToolWindowCommand.png" usedList="bmpPic1, bmpPic2, bmpPicSearch, bmpPicX, bmpPicArrows, bmpPicStrikethrough"/>
-		</Bitmaps>
-	</Commands>
+            <Bitmap guid="guidImages" href="Resources\CodyToolWindowCommand.png" usedList="bmpPic1, bmpPic2, bmpPicSearch, bmpPicX, bmpPicArrows, bmpPicStrikethrough"/>
+        </Bitmaps>
+    </Commands>
 
-	<Symbols>
-		<!-- This is the package guid. -->
-		<GuidSymbol name="guidCodyPackage" value="{9b8925e1-803e-43d9-8f43-c4a4f35b4325}" />
+    <Symbols>
+        <!-- This is the package guid. -->
+        <GuidSymbol name="guidCodyPackage" value="{9b8925e1-803e-43d9-8f43-c4a4f35b4325}" />
 
-		<!-- This is the guid used to group the menu commands together -->
-		<GuidSymbol name="guidCodyPackageCmdSet" value="{0ac9104c-5f89-4834-9360-849c7aa6a198}">
-			<IDSymbol name="CodyEditorContextMenuGroup" value="0x0101" />
-			<IDSymbol name="CodyToolWindowCommandId" value="0x0100" />
+        <!-- This is the guid used to group the menu commands together -->
+        <GuidSymbol name="guidCodyPackageCmdSet" value="{0ac9104c-5f89-4834-9360-849c7aa6a198}">
+            <IDSymbol name="CodyEditorContextMenuGroup" value="0x0101" />
+            <IDSymbol name="CodyToolWindowCommandId" value="0x0100" />
             <IDSymbol name="CodyToolsMenuGroup" value="0x1010" />
-		</GuidSymbol>
 
-		<GuidSymbol name="guidImages" value="{9cf94066-686e-4dd8-99c8-3dee4bfb3f59}" >
-			<IDSymbol name="bmpPic1" value="1" />
-			<IDSymbol name="bmpPic2" value="2" />
-			<IDSymbol name="bmpPicSearch" value="3" />
-			<IDSymbol name="bmpPicX" value="4" />
-			<IDSymbol name="bmpPicArrows" value="5" />
-			<IDSymbol name="bmpPicStrikethrough" value="6" />
-		</GuidSymbol>
-	</Symbols>
+            <IDSymbol name="CodySubmenu" value="0x0102" />
+            <IDSymbol name="CodySubmenuGroup" value="0x0103" />
+            <IDSymbol name="DocumentCodeCommandId" value="0x0104" />
+            <IDSymbol name="GenerateUnitTestsCommandId" value="0x0105" />
+            <IDSymbol name="ExplainCodeCommandId" value="0x0106" />
+            <IDSymbol name="FindCodeSmellsCommandId" value="0x0107" />
+        </GuidSymbol>
 
-	<KeyBindings>
-		<!-- This is the keybinding for opening chat. -->
-		<KeyBinding guid="guidCodyPackageCmdSet" id="CodyToolWindowCommandId" editor="guidVSStd97" key1="L" mod1="Alt" />
-	</KeyBindings>
+        <GuidSymbol name="guidImages" value="{9cf94066-686e-4dd8-99c8-3dee4bfb3f59}" >
+            <IDSymbol name="bmpPic1" value="1" />
+            <IDSymbol name="bmpPic2" value="2" />
+            <IDSymbol name="bmpPicSearch" value="3" />
+            <IDSymbol name="bmpPicX" value="4" />
+            <IDSymbol name="bmpPicArrows" value="5" />
+            <IDSymbol name="bmpPicStrikethrough" value="6" />
+        </GuidSymbol>
+    </Symbols>
+
+    <KeyBindings>
+        <!-- This is the keybinding for opening chat. -->
+        <KeyBinding guid="guidCodyPackageCmdSet" id="CodyToolWindowCommandId" editor="guidVSStd97" key1="L" mod1="Alt" />
+    </KeyBindings>
 </CommandTable>

--- a/src/Cody.VisualStudio/CommandIDs.cs
+++ b/src/Cody.VisualStudio/CommandIDs.cs
@@ -3,5 +3,9 @@ namespace Cody.VisualStudio
     internal static class CommandIds
     {
         public const int CodyToolWindow = 0x0100;
+        public const int DocumentCodeCommandId = 0x0104;
+        public const int GenerateUnitTestsCommandId = 0x0105;
+        public const int ExplainCodeCommandId = 0x0106;
+        public const int FindCodeSmellsCommandId = 0x0107;
     }
 }

--- a/src/Cody.VisualStudio/Services/StatusbarService.cs
+++ b/src/Cody.VisualStudio/Services/StatusbarService.cs
@@ -1,16 +1,20 @@
-using Microsoft.VisualStudio.Shell.Interop;
+using Cody.Core.Infrastructure;
+using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using Cody.Core.Infrastructure;
 
 namespace Cody.VisualStudio.Services
 {
     public class StatusbarService : IStatusbarService
     {
+        private static bool animationIsRunning = false;
+        private object icon = (short)Constants.SBAI_General;
+
         public void SetText(string text)
         {
             ThreadHelper.JoinableTaskFactory.Run(async delegate
@@ -29,6 +33,30 @@ namespace Cody.VisualStudio.Services
             });
 
 
+        }
+
+        public void StartProgressAnimation()
+        {
+            if (animationIsRunning) return;
+            if (EnableProgressAnimation(true)) animationIsRunning = true;
+        }
+
+        public void StopProgressAnimation()
+        {
+            if (!animationIsRunning) return;
+            if (EnableProgressAnimation(false)) animationIsRunning = false;
+        }
+
+        private bool EnableProgressAnimation(bool enable)
+        {
+            return ThreadHelper.JoinableTaskFactory.Run(async delegate
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+                var statusBar = (IVsStatusbar)Package.GetGlobalService(typeof(SVsStatusbar));
+
+                return statusBar.Animation(enable ? 1 : 0, ref icon) == VSConstants.S_OK;
+            });
         }
     }
 }


### PR DESCRIPTION
This PR adds standard commands that automate and speed up workflow in Cody. You get the following core (built-in) prompts:
- document-code
- explain-code
- find-code-smells
- generate-unit-tests

Commands are available when user is logged in. They are available in the editor's context menu. Commands can also be invoked using keyboard shortcuts, which can be configured in Visual Studio settings.
## Test plan
**Scenario I**
1. Select a block of code in the editor (e.g. one function)
2. Click right mouse button and choose Cody > Generate unit tests
3. Make sure new chat with generated unit tests code appears

**Scenario II**
1. Select a block of code in the editor (e.g. one function)
2. Click right mouse button and choose Cody > Explain code
3. Make sure new chat with generated unit tests code appears

**Scenario III**
1. Select a block of code in the editor (e.g. one function)
2. Click right mouse button and choose Cody > Find Code Smells
3. Make sure new chat with generated unit tests code appears

**Scenario IV**
1. Select a block of code in the editor (e.g. one function)
2. Click right mouse button and choose Cody > Document Code
3. Progress animation should appear on the status bar
4. Make sure that code documentation appears in code editor

<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->
