### PR TITLE
NullReferenceException during disconnection

### DIFF
--- a/src/Cody.VisualStudio/Client/AgentClient.cs
+++ b/src/Cody.VisualStudio/Client/AgentClient.cs
@@ -146,7 +146,7 @@ namespace Cody.VisualStudio.Client
 
         private void DisconnectInternal()
         {
-            if (!jsonRpc.IsDisposed) jsonRpc?.Dispose();
+            if (jsonRpc != null && !jsonRpc.IsDisposed) jsonRpc?.Dispose();
             if (connector != null)
             {
                 connector.ErrorReceived -= OnErrorReceived;


### PR DESCRIPTION
An exception is thrown when closing VS and disconnecting from the agent. This PR gives a condition that checks if the object is not null.
## Test plan
N/A
<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->
