### PR TITLE
Support for notifications

### DIFF
--- a/src/Cody.Core/Agent/NotificationHandlers.cs
+++ b/src/Cody.Core/Agent/NotificationHandlers.cs
@@ -255,8 +255,20 @@ namespace Cody.Core.Agent
 
                 return selectedValue;
             }
-
-            _statusbarService.SetText(param.Message);
+            else if (param.Message.StartsWith("Edit applied to"))
+            {
+                _statusbarService.SetText(param.Message);
+            }
+            else if (param.Items != null && param.Items.Count > 0 && !string.IsNullOrEmpty(param.Items[0]))
+            {
+                var result = await _toastNotificationService.ShowNotification(
+                    param.Severity, param.Message, param.Options?.Detail, param.Items);
+                return result;
+            }
+            else
+            {
+                _statusbarService.SetText(param.Message);
+            }
 
             return null;
         }

--- a/src/Cody.Core/Cody.Core.csproj
+++ b/src/Cody.Core/Cody.Core.csproj
@@ -128,6 +128,7 @@
     <Compile Include="Infrastructure\IFileDialogService.cs" />
     <Compile Include="Infrastructure\ISecretStorageService.cs" />
     <Compile Include="Infrastructure\IProgressService.cs" />
+    <Compile Include="Infrastructure\IToastNotificationService.cs" />
     <Compile Include="Logging\ISentryLog.cs" />
     <Compile Include="Logging\ITestLogger.cs" />
     <Compile Include="Logging\SentryLog.cs" />

--- a/src/Cody.Core/Infrastructure/IToastNotificationService.cs
+++ b/src/Cody.Core/Infrastructure/IToastNotificationService.cs
@@ -1,0 +1,14 @@
+using Cody.Core.Agent.Protocol;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Cody.Core.Infrastructure
+{
+    public interface IToastNotificationService
+    {
+        Task<string> ShowNotification(SeverityEnum severity, string message, string details, IEnumerable<string> actions);
+    }
+}

--- a/src/Cody.UI/Cody.UI.csproj
+++ b/src/Cody.UI/Cody.UI.csproj
@@ -64,6 +64,7 @@
     <Compile Include="ViewModels\EditCodeViewModel.cs" />
     <Compile Include="ViewModels\GeneralOptionsViewModel.cs" />
     <Compile Include="ViewModels\MainViewModel.cs" />
+    <Compile Include="ViewModels\ToastViewModel.cs" />
     <Compile Include="Views\EditCodeView.xaml.cs">
       <DependentUpon>EditCodeView.xaml</DependentUpon>
     </Compile>
@@ -71,6 +72,9 @@
       <DependentUpon>MainView.xaml</DependentUpon>
     </Compile>
     <Compile Include="Controls\WebviewController.cs" />
+    <Compile Include="Views\ToastView.xaml.cs">
+      <DependentUpon>ToastView.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Page Include="Controls\Options\GeneralOptionsControl.xaml">
@@ -89,6 +93,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Views\MainView.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Views\ToastView.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/src/Cody.UI/ViewModels/ToastViewModel.cs
+++ b/src/Cody.UI/ViewModels/ToastViewModel.cs
@@ -1,0 +1,89 @@
+using Cody.Core.Agent.Protocol;
+using Cody.UI.MVVM;
+using Microsoft.VisualStudio.Imaging;
+using Microsoft.VisualStudio.Imaging.Interop;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Input;
+
+namespace Cody.UI.ViewModels
+{
+    public class ToastViewModel : NotifyPropertyChangedBase
+    {
+        private Window window;
+
+        public ToastViewModel(Window window, SeverityEnum severity, string message, string details, IEnumerable<string> actions)
+        {
+            this.window = window;
+            Severity = severity;
+            Message = message;
+            Details = details;
+            Actions = new ObservableCollection<string>(actions);
+        }
+
+        public ObservableCollection<string> Actions { get; set; }
+
+        private string message;
+        public string Message
+        {
+            get => message;
+            set => SetProperty(ref message, value);
+        }
+
+        private string details;
+        public string Details
+        {
+            get => details;
+            set => SetProperty(ref details, value);
+        }
+
+        private SeverityEnum severity;
+        public SeverityEnum Severity
+        {
+            get => severity;
+            set => SetProperty(ref severity, value);
+        }
+
+        private DelegateCommand<string> actionCommand;
+        public DelegateCommand<string> ActionCommand
+        {
+            get { return actionCommand = actionCommand ?? new DelegateCommand<string>(OnActionButtonClick); }
+        }
+
+        private void OnActionButtonClick(string actionName)
+        {
+            SelectedAction = actionName;
+            window.Close();
+        }
+
+        private DelegateCommand closeCommand;
+        public DelegateCommand CloseCommand
+        {
+            get { return closeCommand = closeCommand ?? new DelegateCommand(OnCloseButtonClick); }
+        }
+
+        private void OnCloseButtonClick() => window.Close();
+
+        public ImageMoniker Moniker
+        {
+            get
+            {
+                switch (severity)
+                {
+                    case SeverityEnum.Error: return KnownMonikers.StatusError;
+                    case SeverityEnum.Warning: return KnownMonikers.StatusWarning;
+                    case SeverityEnum.Information:
+                    default:
+                        return KnownMonikers.StatusInformation;
+                }
+            }
+        }
+
+        public string SelectedAction { get; protected set; }
+    }
+}

--- a/src/Cody.UI/Views/ToastView.xaml
+++ b/src/Cody.UI/Views/ToastView.xaml
@@ -1,0 +1,132 @@
+<Window xmlns:platformui="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.15.0"
+        xmlns:theme="clr-namespace:Community.VisualStudio.Toolkit"
+        xmlns:imaging="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.Imaging"
+        xmlns:catalog="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.ImageCatalog"
+        xmlns:vsshell="clr-namespace:Microsoft.VisualStudio.Shell;assembly=Microsoft.VisualStudio.Shell.15.0"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+               xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+               x:Class="Cody.UI.Views.ToastView"
+               Height="105"
+               Width="350"
+               WindowStyle="None"
+               BorderThickness="1"
+               BorderBrush="{DynamicResource {x:Static vsshell:VsBrushes.ToolWindowBorderKey}}"
+               WindowStartupLocation="Manual"
+               ResizeMode="NoResize"
+               AllowsTransparency="True"
+               ShowInTaskbar="False"
+               SizeToContent="Height"
+               theme:Themes.UseVsTheme="True"
+               >
+    <FrameworkElement.Resources>
+        <Style x:Key="IgnoreButtonStyle" TargetType="{x:Type Button}">
+            <Setter Property="Control.BorderThickness" Value="0"/>
+            <Setter Property="Control.HorizontalContentAlignment" Value="Center"/>
+            <Setter Property="Control.VerticalContentAlignment" Value="Center"/>
+            <Setter Property="FrameworkElement.UseLayoutRounding" Value="True"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="{x:Type Button}">
+                        <Border Background="{TemplateBinding Background}" BorderThickness="{TemplateBinding BorderThickness}" BorderBrush="{TemplateBinding BorderBrush}">
+                            <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center" />
+                        </Border>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+            <Style.Triggers>
+                <Trigger Property="IsMouseOver" Value="True">
+                    <Setter Property="BorderBrush" Value="{DynamicResource {x:Static vsshell:VsBrushes.ToolWindowButtonHoverInactiveBorderKey}}"/>
+                    <Setter Property="Foreground" Value="{DynamicResource {x:Static vsshell:VsBrushes.ToolWindowButtonHoverInactiveGlyphKey}}"/>
+                    <Setter Property="Background" Value="{DynamicResource {x:Static vsshell:VsBrushes.ToolWindowButtonHoverInactiveKey}}"/>
+                    <Setter Property="BorderThickness" Value="1"/>
+                </Trigger>
+                <Trigger Property="IsMouseOver" Value="False">
+                    <Setter Property="BorderThickness" Value="0"/>
+                    <Setter Property="Foreground" Value="{DynamicResource {x:Static vsshell:VsBrushes.ToolWindowButtonInactiveGlyphKey}}"/>
+                    <Setter Property="Background" Value="Transparent"/>
+                </Trigger>
+            </Style.Triggers>
+        </Style>
+        <Style x:Key="DismissGlyphStyleKey" TargetType="{x:Type Path}">
+            <Setter Property="Shape.Fill">
+                <Setter.Value>
+                    <Binding Path="(TextElement.Foreground)" RelativeSource="{RelativeSource Self}"/>
+                </Setter.Value>
+            </Setter>
+            <Setter Property="FrameworkElement.Height" Value="10"/>
+            <Setter Property="FrameworkElement.Width" Value="10"/>
+            <Setter Property="Shape.Stretch" Value="Uniform"/>
+        </Style>
+        <Path x:Key="DismissGlyphPathKey" x:Name="DismissGlyph" x:Uid="DismissGlyph"
+          Data="F1 M 0,0 L 2,0 5,3 8,0 10,0 6,4 10,8 8,8 5,5 2,8 0,8 4,4 0,0 Z"
+          Style="{StaticResource DismissGlyphStyleKey}"/>
+    </FrameworkElement.Resources>
+    <StackPanel Margin="12">
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="32"/>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+
+            <imaging:CrispImage Grid.Column="0"
+                                Width="24"
+                                Height="24"
+                                Margin="2,2,0,0"
+                                VerticalAlignment="Top"
+                                Moniker="{Binding Moniker}"/>
+
+
+            <StackPanel Grid.Column="1"
+                        Margin="8,0,20,0"
+                        Orientation="Vertical"
+                        VerticalAlignment="Top"
+                        HorizontalAlignment="Left">
+                <TextBlock Margin="0,0,0,8" FontWeight="SemiBold" Text="{Binding Message}" TextWrapping="Wrap" Visibility="Visible">
+                </TextBlock>
+                <TextBlock Margin="0" Text="{Binding Details}" TextWrapping="Wrap">
+                    <TextBlock.Style>
+                        <Style TargetType="TextBlock">
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding Details}" Value="{x:Null}">
+                                    <Setter Property="Visibility" Value="Collapsed"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </TextBlock.Style>
+                </TextBlock>
+            </StackPanel>
+
+            <Button Grid.Column="2"
+                    Width="14"
+                    Height="14"
+                    Margin="0,-6,-6,0"
+                    HorizontalAlignment="Right"
+                    VerticalAlignment="Top"
+                    IsCancel="True"
+                    Focusable="False"
+                    Command="{Binding CloseCommand}"
+                    Style="{StaticResource IgnoreButtonStyle}">
+                <StaticResourceExtension ResourceKey="DismissGlyphPathKey"/>
+            </Button>
+            
+        </Grid>
+        <StackPanel x:Name="ActionButtonPanel" Margin="46,17,0,0" HorizontalAlignment="Right" Orientation="Horizontal">
+            <ItemsControl ItemsSource="{Binding Actions}">
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <StackPanel Orientation="Horizontal"/>
+                    </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <Button Margin="0,0,6,0"
+                                Content="{Binding}"
+                                Command="{Binding DataContext.ActionCommand, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                CommandParameter="{Binding}"/>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+        </StackPanel>
+    </StackPanel>
+</Window>

--- a/src/Cody.UI/Views/ToastView.xaml.cs
+++ b/src/Cody.UI/Views/ToastView.xaml.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Interop;
+
+namespace Cody.UI.Views
+{
+    /// <summary>
+    /// Interaction logic for ToastView.xaml
+    /// </summary>
+    public partial class ToastView : Window
+    {
+        private const int windowMargin = 30;
+
+        public ToastView()
+        {
+            InitializeComponent();
+
+            this.Loaded += OnLoaded;
+        }
+
+        private void OnLoaded(object sender, RoutedEventArgs e)
+        {
+            if (this.Owner != null)
+            {
+                this.Owner.LocationChanged += OnOwnerLocationChanged;
+                this.Owner.SizeChanged += OnOwnerSizeChanged;
+                this.Owner.StateChanged += OnOwnerStateChanged;
+            }
+        }
+
+        private void OnOwnerStateChanged(object sender, EventArgs e) => PositionWindow();
+
+        private void OnOwnerLocationChanged(object sender, EventArgs e) => PositionWindow();
+
+        private void OnOwnerSizeChanged(object sender, SizeChangedEventArgs e) => PositionWindow();
+
+        public void PositionWindow()
+        {
+            if (this.Owner == null) return;
+
+            if (this.Owner.WindowState == WindowState.Maximized)
+            {
+                var ownerBounds = Win32Bounds.GetOwnerAnchorRect(this);
+
+                this.Left = ownerBounds.Right - this.ActualWidth - windowMargin;
+                this.Top = ownerBounds.Bottom - this.ActualHeight - windowMargin;
+            }
+            else
+            {
+                this.Left = this.Owner.Left + this.Owner.ActualWidth - this.ActualWidth - windowMargin;
+                this.Top = this.Owner.Top + this.Owner.ActualHeight - this.ActualHeight - windowMargin;
+            }
+        }
+
+        protected override void OnClosed(EventArgs e)
+        {
+            if (this.Owner != null)
+            {
+                this.Owner.LocationChanged -= OnOwnerLocationChanged;
+                this.Owner.SizeChanged -= OnOwnerSizeChanged;
+                this.Owner.StateChanged -= OnOwnerStateChanged;
+            }
+            base.OnClosed(e);
+        }
+    }
+
+
+    static class Win32Bounds
+    {
+        [StructLayout(LayoutKind.Sequential)]
+        private struct RECT { public int Left, Top, Right, Bottom; }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct MONITORINFO
+        {
+            public int cbSize;
+            public RECT rcMonitor; // entire monitor (device px)
+            public RECT rcWork;    // working area (device px, excludes taskbar)
+            public uint dwFlags;
+        }
+
+        [DllImport("user32.dll")]
+        private static extern IntPtr MonitorFromWindow(IntPtr hwnd, uint dwFlags);
+
+        [DllImport("user32.dll", SetLastError = true)]
+        private static extern bool GetMonitorInfo(IntPtr hMonitor, ref MONITORINFO lpmi);
+
+        private const uint MONITOR_DEFAULTTONEAREST = 2;
+
+        public static Rect GetOwnerAnchorRect(Window owner)
+        {
+            var hwnd = new WindowInteropHelper(owner).Handle;
+            var hmon = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
+            var mi = new MONITORINFO { cbSize = Marshal.SizeOf<MONITORINFO>() };
+            if (GetMonitorInfo(hmon, ref mi))
+                return DeviceRectToDips(mi.rcWork, hwnd);
+
+            return new Rect();
+        }
+
+        private static Rect DeviceRectToDips(RECT r, IntPtr hwnd)
+        {
+            var src = HwndSource.FromHwnd(hwnd);
+            var fromDevice = src.CompositionTarget.TransformFromDevice;
+            var tl = fromDevice.Transform(new Point(r.Left, r.Top));
+            var br = fromDevice.Transform(new Point(r.Right, r.Bottom));
+            return new Rect(tl, br);
+        }
+    }
+}

--- a/src/Cody.VisualStudio/Cody.VisualStudio.csproj
+++ b/src/Cody.VisualStudio/Cody.VisualStudio.csproj
@@ -78,6 +78,7 @@
     <Compile Include="Services\TestingSupportService.cs" />
     <Compile Include="Services\ThemeService.cs" />
     <Compile Include="Services\StatusbarService.cs" />
+    <Compile Include="Services\ToastNotificationService.cs" />
     <Compile Include="Services\UserSettingsProvider.cs" />
     <Compile Include="Services\VsVersionService.cs" />
     <Compile Include="Utilities\FilePathHelper.cs" />

--- a/src/Cody.VisualStudio/CodyPackage.cs
+++ b/src/Cody.VisualStudio/CodyPackage.cs
@@ -70,6 +70,7 @@ namespace Cody.VisualStudio
         public IConfigurationService ConfigurationService;
         public IFileDialogService FileDialogService;
         public IEditCodeService EditCodeService;
+        public IToastNotificationService ToastNotificationService;
 
         private IInfobarNotifications InfobarNotifications;
 
@@ -172,8 +173,10 @@ namespace Cody.VisualStudio
             TestingSupportService = null; // new TestingSupportService(statusCenterService);
             VsEditorAdaptersFactoryService = componentModel.GetService<IVsEditorAdaptersFactoryService>();
             DocumentService = new DocumentService(Logger, this, vsSolution, VsEditorAdaptersFactoryService);
+            ToastNotificationService = new ToastNotificationService(Logger);
 
-            NotificationHandlers = new NotificationHandlers(UserSettingsService, AgentNotificationsLogger, DocumentService, SecretStorageService, InfobarNotificationsAsync);
+            NotificationHandlers = new NotificationHandlers(UserSettingsService, AgentNotificationsLogger,
+                DocumentService, SecretStorageService, InfobarNotificationsAsync, StatusbarService, ToastNotificationService);
 
             NotificationHandlers.OnOptionsPageShowRequest += HandleOnOptionsPageShowRequest;
             NotificationHandlers.OnFocusSidebarRequest += HandleOnFocusSidebarRequest;
@@ -312,18 +315,18 @@ namespace Cody.VisualStudio
 
                     var host = obj as IVsInfoBarHost;
                     if (host != null)
-        {
+                    {
                         //Logger.Debug($"InitializeInfoBarService:{host}");
 
                         var uiFactory = ServiceProvider.GlobalProvider.GetService(typeof(SVsInfoBarUIFactory)) as IVsInfoBarUIFactory;
                         if (uiFactory != null)
-        {
+                        {
                             InfobarNotifications = new InfobarNotifications(host, uiFactory, AgentNotificationsLogger);
                             _infobarNotificationsCompletionSource.SetResult(InfobarNotifications);
 
                         }
                         else
-                    {
+                        {
                             Logger.Error("Cannot get IVsInfoBarUIFactory");
                         }
 
@@ -476,8 +479,8 @@ namespace Cody.VisualStudio
                 {
                     var documentSyncCallback = new DocumentSyncCallback(AgentService, Logger);
                     DocumentsSyncService = new DocumentsSyncService(VsUIShell, documentSyncCallback, VsEditorAdaptersFactoryService, UserSettingsService, Logger);
-                DocumentsSyncService.Initialize();
-            }
+                    DocumentsSyncService.Initialize();
+                }
             }
             catch (Exception ex)
             {

--- a/src/Cody.VisualStudio/Services/ToastNotificationService.cs
+++ b/src/Cody.VisualStudio/Services/ToastNotificationService.cs
@@ -1,0 +1,55 @@
+using Cody.Core.Agent.Protocol;
+using Cody.Core.Infrastructure;
+using Cody.Core.Logging;
+using Cody.UI.ViewModels;
+using Cody.UI.Views;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Threading;
+
+namespace Cody.VisualStudio.Services
+{
+    public class ToastNotificationService : IToastNotificationService
+    {
+        public ToastNotificationService(ILog log)
+        {
+            this.log = log;
+        }
+
+        private static ToastView currentView = null;
+        private readonly ILog log;
+
+        public async Task<string> ShowNotification(SeverityEnum severity, string message, string details, IEnumerable<string> actions)
+        {
+            if (currentView != null)
+            {
+                currentView.Close();
+            }
+
+            var result = new TaskCompletionSource<string>();
+            currentView = new ToastView();
+            var vm = new ToastViewModel(currentView, severity, message, details, actions);
+
+            currentView.DataContext = vm;
+            currentView.Closed += (sender, e) =>
+            {
+                currentView = null;
+                result.SetResult(vm.SelectedAction);
+            };
+
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+            currentView.Owner = Application.Current.MainWindow;
+            currentView.Show();
+            currentView.PositionWindow();
+
+            return await result.Task;
+        }
+    }
+}

--- a/src/Cody.VisualStudio/Services/ToastNotificationService.cs
+++ b/src/Cody.VisualStudio/Services/ToastNotificationService.cs
@@ -27,14 +27,15 @@ namespace Cody.VisualStudio.Services
 
         public async Task<string> ShowNotification(SeverityEnum severity, string message, string details, IEnumerable<string> actions)
         {
-            if (currentView != null)
-            {
-                currentView.Close();
-            }
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+            if (currentView != null) currentView.Close();
+
+            var actionsList = actions != null ? actions.Where(x => !string.IsNullOrEmpty(x)) : new List<string>();
 
             var result = new TaskCompletionSource<string>();
             currentView = new ToastView();
-            var vm = new ToastViewModel(currentView, severity, message, details, actions);
+            var vm = new ToastViewModel(currentView, severity, message, details, actionsList);
 
             currentView.DataContext = vm;
             currentView.Closed += (sender, e) =>
@@ -42,8 +43,6 @@ namespace Cody.VisualStudio.Services
                 currentView = null;
                 result.SetResult(vm.SelectedAction);
             };
-
-            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
             currentView.Owner = Application.Current.MainWindow;
             currentView.Show();

--- a/src/Cody.VisualStudio/Services/ToastNotificationService.cs
+++ b/src/Cody.VisualStudio/Services/ToastNotificationService.cs
@@ -27,28 +27,36 @@ namespace Cody.VisualStudio.Services
 
         public async Task<string> ShowNotification(SeverityEnum severity, string message, string details, IEnumerable<string> actions)
         {
-            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-
-            if (currentView != null) currentView.Close();
-
-            var actionsList = actions != null ? actions.Where(x => !string.IsNullOrEmpty(x)) : new List<string>();
-
-            var result = new TaskCompletionSource<string>();
-            currentView = new ToastView();
-            var vm = new ToastViewModel(currentView, severity, message, details, actionsList);
-
-            currentView.DataContext = vm;
-            currentView.Closed += (sender, e) =>
+            try
             {
-                currentView = null;
-                result.SetResult(vm.SelectedAction);
-            };
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-            currentView.Owner = Application.Current.MainWindow;
-            currentView.Show();
-            currentView.PositionWindow();
+                if (currentView != null) currentView.Close();
 
-            return await result.Task;
+                var actionsList = actions != null ? actions.Where(x => !string.IsNullOrEmpty(x)) : new List<string>();
+
+                var result = new TaskCompletionSource<string>();
+                currentView = new ToastView();
+                var vm = new ToastViewModel(currentView, severity, message, details, actionsList);
+
+                currentView.DataContext = vm;
+                currentView.Closed += (sender, e) =>
+                {
+                    currentView = null;
+                    result.SetResult(vm.SelectedAction);
+                };
+
+                currentView.Owner = Application.Current.MainWindow;
+                currentView.Show();
+                currentView.PositionWindow();
+
+                return await result.Task;
+            }
+            catch (Exception ex)
+            {
+                log.Error("Show notification error", ex);
+                return null;
+            }
         }
     }
 }


### PR DESCRIPTION
This PR adds support for notifications from the agent. They can appear as text in the status bar or as a window popping up in the lower right corner of the main window. The window version appears when the notification contains actions. In this case, they appear as buttons in the window.
## Test plan
1. Log out of Cody
2. Log in again
3. A notification should appear in the status bar: "Signed in to `url`"
<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->
