### PR TITLE
textEditor/selection and textEditor/revealRange endpoints

### DIFF
--- a/src/Cody.Core/Agent/EditTaskNotificationHandlers.cs
+++ b/src/Cody.Core/Agent/EditTaskNotificationHandlers.cs
@@ -3,9 +3,7 @@ using Cody.Core.Common;
 using Cody.Core.Infrastructure;
 using Cody.Core.Logging;
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Cody.Core.Agent
@@ -29,9 +27,15 @@ namespace Cody.Core.Agent
         [AgentCallback("textEditor/selection")]
         public void Selection(string uri, Range selection)
         {
-            // no needed yet
-            //var path = uri.ToWindowsPath();
-            //documentService.SelectInDocument(path, selection);
+            var path = uri.ToWindowsPath();
+            documentService.SelectInDocument(path, selection);
+        }
+
+        [AgentCallback("textEditor/revealRange")]
+        public void RevealRange(string uri, Range range)
+        {
+            var path = uri.ToWindowsPath();
+            documentService.RevealRangeInDocument(path, range);
         }
 
         [AgentCallback("editTask/getUserInput", deserializeToSingleObject: true)]

--- a/src/Cody.Core/Infrastructure/IDocumentService.cs
+++ b/src/Cody.Core/Infrastructure/IDocumentService.cs
@@ -13,6 +13,8 @@ namespace Cody.Core.Infrastructure
 
         bool SelectInDocument(string path, Range selection);
 
+        bool RevealRangeInDocument(string path, Range range);
+
         bool InsertTextInDocument(string path, Position position, string text);
 
         bool ReplaceTextInDocument(string path, Range range, string text);


### PR DESCRIPTION
Implementation of `textEditor/selection` and `textEditor/revealRange` endpoints. With their help agent will be able to select and scroll through code. Such actions are used by the agent, for example, during edits to show the user what has been changed at the end of larger file.
## Test plan
N/A
<!-- REQUIRED; info at https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles -->
