### PR TITLE
Switched default logger to "Cody Notifications" for WebviewNotificationHandlers

### DIFF
--- a/src/Cody.VisualStudio/CodyPackage.cs
+++ b/src/Cody.VisualStudio/CodyPackage.cs
@@ -179,7 +179,7 @@ namespace Cody.VisualStudio
 
             NotificationHandlers = new NotificationHandlers(UserSettingsService, AgentNotificationsLogger,
                 DocumentService, InfobarNotificationsAsync, StatusbarService, ToastNotificationService);
-            WebviewNotificationHandlers = new WebviewNotificationHandlers(Logger);
+            WebviewNotificationHandlers = new WebviewNotificationHandlers(AgentNotificationsLogger);
             SecretNotificationHandlers = new SecretNotificationHandlers(SecretStorageService, Logger);
 
             WebviewNotificationHandlers.OnOptionsPageShowRequest += HandleOnOptionsPageShowRequest;


### PR DESCRIPTION
CI was failing after WebviewNotificationHandlers has started using default logger (too much logs to handle by CI).



## Test plan

1. "Cody" output window is not showing anymore calls to `WebviewNotificationHandlers.PostMessageStringEncoded]`
