### PR TITLE
[UI Tests] Changed text for detecting login screen

### DIFF
--- a/src/Cody.VisualStudio.Tests/PlaywrightTestsBase.cs
+++ b/src/Cody.VisualStudio.Tests/PlaywrightTestsBase.cs
@@ -114,7 +114,7 @@ namespace Cody.VisualStudio.Tests
 
         protected async Task WaitForLogOutState()
         {
-            await Page.WaitForSelectorAsync("text=By signing in to Cody");
+            await Page.WaitForSelectorAsync("text=Let's get you started");
         }
 
         protected async Task WaitForLogInState()


### PR DESCRIPTION
Changed text for detecting login screen. The old text is probably not visible to Playwright, because Cody notification covers it. Although is should be rendered fine, but maybe this is the issue caused by WebView2 rendered on top of other controls (current version which is used), but in this case it is covered by "Cody notification" window.

<img width="369" height="127" alt="image" src="https://github.com/user-attachments/assets/80aed06c-8190-4f0f-9ef7-cf43c1d5ec78" />


## Test plan

1. Green `Cody_Enterprise_Section_Is_Present()` test.

